### PR TITLE
Fix error in Activating cgroup support for raspbian.

### DIFF
--- a/roles/raspbian/tasks/main.yml
+++ b/roles/raspbian/tasks/main.yml
@@ -15,8 +15,7 @@
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true
   notify: reboot
-  when:
-    - raspbian is true
+  when: raspbian
 
 - name: Flush iptables before changing to iptables-legacy
   iptables:


### PR DESCRIPTION
Fixing a regression introduced by PR #63, for the error mentioned in the issue #49 .