### PR TITLE
Don't overdo things

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -1,9 +1,27 @@
 ---
 
-- name: Delete k3s if already present
+- name: Check if k3s binary is present
+  stat:
+    path: /usr/local/bin/k3s
+  register: k3s_bin
+
+- name: K3s version check
+  command: /usr/local/bin/k3s --version
+  register: ks3_local_version
+  when: k3s_bin.stat.exists == True
+
+- name: Delete k3s if already present and the wrong version
   file:
     path: /usr/local/bin/k3s
     state: absent
+  when:
+    - k3s_bin.stat.exists == True
+    - ks3_local_version.stdout.find(k3s_version) == -1 
+
+- name: Check if k3s binary is present
+  stat:
+    path: /usr/local/bin/k3s
+  register: k3s_bin
 
 - name: Download k3s binary x64
   get_url:
@@ -12,7 +30,9 @@
     owner: root
     group: root
     mode: 0755
-  when: ansible_facts.architecture == "x86_64"
+  when:
+    - k3s_bin.stat.exists == False
+    - ansible_facts.architecture == "x86_64"
 
 - name: Download k3s binary arm64
   get_url:
@@ -22,6 +42,7 @@
     group: root
     mode: 0755
   when:
+    - k3s_bin.stat.exists == False
     - ( ansible_facts.architecture is search("arm") and
         ansible_facts.userspace_bits == "64" ) or
       ansible_facts.architecture is search("aarch64")
@@ -34,5 +55,6 @@
     group: root
     mode: 0755
   when:
+    - k3s_bin.stat.exists == False
     - ansible_facts.architecture is search("arm")
     - ansible_facts.userspace_bits == "32"

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -9,6 +9,7 @@
   command: /usr/local/bin/k3s --version
   register: ks3_local_version
   when: k3s_bin.stat.exists
+  check_mode: no
 
 - name: Delete k3s if already present and the wrong version
   file:

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -16,7 +16,7 @@
     state: absent
   when:
     - k3s_bin.stat.exists == True
-    - ks3_local_version.stdout.find(k3s_version) == -1 
+    - ks3_local_version.stdout.find(k3s_version) == -1
 
 - name: Check if k3s binary is present
   stat:

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -8,14 +8,14 @@
 - name: K3s version check
   command: /usr/local/bin/k3s --version
   register: ks3_local_version
-  when: k3s_bin.stat.exists == True
+  when: k3s_bin.stat.exists
 
 - name: Delete k3s if already present and the wrong version
   file:
     path: /usr/local/bin/k3s
     state: absent
   when:
-    - k3s_bin.stat.exists == True
+    - not k3s_bin.stat.exists
     - ks3_local_version.stdout.find(k3s_version) == -1
 
 - name: Check if k3s binary is present
@@ -31,7 +31,7 @@
     group: root
     mode: 0755
   when:
-    - k3s_bin.stat.exists == False
+    - not k3s_bin.stat.exists
     - ansible_facts.architecture == "x86_64"
 
 - name: Download k3s binary arm64
@@ -42,7 +42,7 @@
     group: root
     mode: 0755
   when:
-    - k3s_bin.stat.exists == False
+    - not k3s_bin.stat.exists
     - ( ansible_facts.architecture is search("arm") and
         ansible_facts.userspace_bits == "64" ) or
       ansible_facts.architecture is search("aarch64")
@@ -55,6 +55,6 @@
     group: root
     mode: 0755
   when:
-    - k3s_bin.stat.exists == False
+    - not k3s_bin.stat.exists
     - ansible_facts.architecture is search("arm")
     - ansible_facts.userspace_bits == "32"

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -49,6 +49,7 @@
     path: ~{{ ansible_user }}/.kube
     state: directory
     owner: "{{ ansible_user }}"
+    mode: 0750
 
 - name: Copy config file to user home directory
   copy:
@@ -56,6 +57,7 @@
     dest: ~{{ ansible_user }}/.kube/config
     remote_src: yes
     owner: "{{ ansible_user }}"
+    mode: 0600
 
 - name: Replace https://localhost:6443 by https://master-ip:6443
   command: >-

--- a/roles/k3s/node/tasks/main.yml
+++ b/roles/k3s/node/tasks/main.yml
@@ -12,5 +12,5 @@
   systemd:
     name: k3s-node
     daemon_reload: yes
-    state: restarted
+    state: started
     enabled: yes

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -22,6 +22,7 @@
   copy:
     content: "br_netfilter"
     dest: /etc/modules-load.d/br_netfilter.conf
+    mode: 0600
   when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
 
 - name: Load br_netfilter

--- a/roles/ubuntu/tasks/main.yml
+++ b/roles/ubuntu/tasks/main.yml
@@ -9,6 +9,7 @@
     - ansible_distribution == 'Ubuntu'
     - ( ansible_facts.architecture is search("arm") or
         ansible_facts.architecture is search("aarch64") )
+  register: enable_cgroup
 
 - name: Reboot to enable cgroups for Ubuntu on ARM
   reboot:
@@ -16,3 +17,4 @@
     - ansible_distribution == 'Ubuntu'
     - ( ansible_facts.architecture is search("arm") or
         ansible_facts.architecture is search("aarch64") )
+    - enable_cgroup.changed


### PR DESCRIPTION
I found that running the example multiple times it kept rebooting nodes, redownloading the binary file and restarting the service.

My setup:
[leader]
Raspberry Pi 4 Ubuntu 20.04 64ARM

[minions]
2x Raspberry Pi 3B+ Ubuntu 20.04 64ARM


The k3s version I'm running is `v1.18.6+k3s1`

The only change that remains in the playbook for me is the k3s version check.
If someone has an even cleaner way of checking the k3s version without incurring any changes that would be awesome.
