### PR TITLE
Fix raspbian role on centos

### DIFF
--- a/roles/raspbian/defaults/main.yml
+++ b/roles/raspbian/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+raspbian: false

--- a/roles/raspbian/tasks/main.yml
+++ b/roles/raspbian/tasks/main.yml
@@ -1,12 +1,18 @@
 ---
 - name: Test for Raspbian
   set_fact:
-    raspbian: '{% if
-      ( ansible_facts.architecture is search("arm") and
-        ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster") ) or
-      ( ansible_facts.architecture is search("aarch64") and
+    raspbian: true
+  when: >-
+    (
+      ansible_facts.architecture is search("arm") and
+      ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster")
+    ) or (
+      ansible_facts.architecture is search("aarch64") and
+      (
         ansible_facts.lsb.description is match("Debian.*buster") or
-        ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster") ) %}true{% else %}false{% endif %}'
+        ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster")
+      )
+    )
 
 - name: Activating cgroup support
   lineinfile:
@@ -15,8 +21,7 @@
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true
   notify: reboot
-  when:
-    - raspbian is true
+  when: raspbian
 
 - name: Flush iptables before changing to iptables-legacy
   iptables:


### PR DESCRIPTION
CentOS based OSes don't have the contents of `ansible_facts.lsb.description` populated by Ansible facts gathering, so the detection of Raspbian causes the playbook to fail with this on Ansible 2.8.11:

```
TASK [raspbian : Test for Raspbian] ******************************************************************************************************************************************
fatal: [k3s-node-01]: FAILED! => {}

MSG:

Unexpected templating type error occurred on ({% if ( ansible_facts.architecture is search("arm") and ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster") ) or (              ansible_facts.architecture is search("aarch64") and ansible_facts.lsb.description is match("Debian.*buster") or ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster             ") ) %}true{% else %}false{% endif %}): expected string or bytes-like object
```

on Ansible 2.9.13 this is the error:
```
TASK [raspbian : Test for Raspbian] *******************************************************************************************************************************************************
fatal: [k3s-node-01]: FAILED! => {}

MSG:

The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'description'

The error appears to be in '/home/matt.calvert/git/ansible/k3s/roles/raspbian/tasks/main.yml': line 2, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
- name: Test for Raspbian
  ^ here
```

This MR changes the logic so that `raspbian` is set to `false` by default, and it gets set to `true` by the existing `set_fact` task if a raspbian OS is detected.