### PR TITLE
Raspbian role fix

### DIFF
--- a/roles/raspbian/tasks/main.yml
+++ b/roles/raspbian/tasks/main.yml
@@ -15,8 +15,7 @@
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true
   notify: reboot
-  when:
-    - raspbian is true
+  when: raspbian
 
 - name: Flush iptables before changing to iptables-legacy
   iptables:


### PR DESCRIPTION
Running raspbian 5.4.51+ and getting the error:

FAILED! => {"msg": "The conditional check 'raspbian is true' failed. The error was: template error while templating string: 
no test named 'true'. String: {% if raspbian is true %} True {% else %} False {% endif %}\n\nThe error appears to be in '/root/k3s-ansible/roles/raspbian/tasks/main.yml': line 11, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Activating cgroup support\n  ^ here\n"}

This proposed change fixes the playbook in my instance.