### PR TITLE
Support HA mode with embedded DB

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -7,3 +7,5 @@ rules:
     level: warning
   truthy:
     allowed-values: ['true', 'false', 'yes', 'no']
+  braces:
+    max-spaces-inside: 1

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Master and nodes must have passwordless SSH access
 First create a new directory based on the `sample` directory within the `inventory` directory:
 
 ```bash
+pip install -r requirements.txt
 cp -R inventory/sample inventory/my-cluster
 ```
 
@@ -42,6 +43,10 @@ Second, edit `inventory/my-cluster/hosts.ini` to match the system information ga
 master
 node
 ```
+
+If multiple hosts are in the master group, the playbook will automatically setup k3s in HA mode with etcd.
+https://rancher.com/docs/k3s/latest/en/installation/ha-embedded/
+This requires at least k3s version 1.19.1
 
 If needed, you can also edit `inventory/my-cluster/group_vars/all.yml` to match your environment.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Master and nodes must have passwordless SSH access
 First create a new directory based on the `sample` directory within the `inventory` directory:
 
 ```bash
-pip install -r requirements.txt
 cp -R inventory/sample inventory/my-cluster
 ```
 

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -7,9 +7,10 @@ systemd_dir: /etc/systemd/system
 # apiserver endpoint to all masters here. This default value is only suitable
 # for a non-HA setup, if used in a HA setup, it will not protect you if the
 # first node fails.
+# Also you should define k3s_token so that masters can talk together securely
 
 apiserver_endpoint: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}"
+# k3s_token: "mysupersecuretoken"
 
 extra_server_args: ""
 extra_agent_args: ""
-k3s_token: ""

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -7,9 +7,12 @@ systemd_dir: /etc/systemd/system
 # apiserver endpoint to all masters here. This default value is only suitable
 # for a non-HA setup, if used in a HA setup, it will not protect you if the
 # first node fails.
-# Also you should define k3s_token so that masters can talk together securely
 
 apiserver_endpoint: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}"
+apiserver_port: 6443
+
+# Also you should define k3s_token so that masters can talk together securely
+
 # k3s_token: "mysupersecuretoken"
 
 extra_server_args: ""

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -2,6 +2,14 @@
 k3s_version: v1.22.3+k3s1
 ansible_user: debian
 systemd_dir: /etc/systemd/system
-master_ip: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}"
+
+# If you define multiple masters you should be providing a loadbalanced
+# apiserver endpoint to all masters here. This default value is only suitable
+# for a non-HA setup, if used in a HA setup, it will not protect you if the
+# first node fails.
+
+apiserver_endpoint: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}"
+
 extra_server_args: ""
 extra_agent_args: ""
+k3s_token: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jmespath

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-jmespath

--- a/roles/k3s/master/defaults/main.yml
+++ b/roles/k3s/master/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ansible_user: root
 k3s_server_location: /var/lib/rancher/k3s
-server_init_args: >-
+k3s_server_init_args: >-
   {% if groups['master'] | length > 1 %}
     {% if ansible_host == hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) %}
       --cluster-init

--- a/roles/k3s/master/defaults/main.yml
+++ b/roles/k3s/master/defaults/main.yml
@@ -3,10 +3,10 @@ ansible_user: root
 k3s_server_location: /var/lib/rancher/k3s
 server_init_args: >-
   {% if groups['master'] | length > 1 %}
-    {% if ansible_host == groups['master'][0] %}
+    {% if ansible_host == hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) %}
       --cluster-init
     {% else %}
-      --server https://{{ groups['master'][0] }}:6443
+      --server https://{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}:6443
     {% endif %}
   {% endif %}
   {{ extra_server_args | default('') }}

--- a/roles/k3s/master/defaults/main.yml
+++ b/roles/k3s/master/defaults/main.yml
@@ -8,5 +8,6 @@ server_init_args: >-
     {% else %}
       --server https://{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}:6443
     {% endif %}
+    --token {{ k3s_token }}
   {% endif %}
   {{ extra_server_args | default('') }}

--- a/roles/k3s/master/defaults/main.yml
+++ b/roles/k3s/master/defaults/main.yml
@@ -1,2 +1,12 @@
 ---
+ansible_user: root
 k3s_server_location: /var/lib/rancher/k3s
+server_init_args: >-
+  {% if groups['master'] | length > 1 %}
+    {% if ansible_host == groups['master'][0] %}
+      --cluster-init
+    {% else %}
+      --server https://{{ groups['master'][0] }}:6443
+    {% endif %}
+  {% endif %}
+  {{ extra_server_args | default('') }}

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -27,12 +27,9 @@
   block:
     - name: Verify that all nodes actually joined
       command:
-        cmd: k3s kubectl get --raw /api/v1/nodes/
-        creates: "{{ systemd_dir }}/k3s.service"
+        cmd: k3s kubectl get nodes -l "node-role.kubernetes.io/master=true" -o=jsonpath="{.items[*].metadata.name}"
       register: nodes
-      until: nodes.rc == 0 and
-        ((nodes.stdout | from_json)['items'] |
-        json_query('[*].metadata.labels."node-role.kubernetes.io/master"') | count) == (groups['master'] | length)
+      until: nodes.rc == 0 and (nodes.stdout.split() | length) == (groups['master'] | length)
       retries: 20
       delay: 10
       changed_when: false

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -16,7 +16,6 @@
   command:
     cmd: "systemd-run -p RestartSec=2 \
                       -p Restart=on-failure \
-                      -E K3S_TOKEN={{ k3s_token }} \
                       --unit=k3s-init \
                       k3s server {{ server_init_args }}"
     creates: "{{ systemd_dir }}/k3s.service"

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Verification
   block:
-    - name: Verify that all nodes actually joined
+    - name: Verify that all nodes actually joined (check k3s-init.service if this fails)
       command:
         cmd: k3s kubectl get nodes -l "node-role.kubernetes.io/master=true" -o=jsonpath="{.items[*].metadata.name}"
       register: nodes

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -1,4 +1,47 @@
 ---
+- name: Clean previous runs of k3s-init
+  systemd:
+    name: k3s-init
+    state: stopped
+  failed_when: false
+
+- name: Clean previous runs of k3s-init
+  command: systemctl reset-failed k3s-init
+  failed_when: false
+  changed_when: false
+  args:
+    warn: false  # The ansible systemd module does not support reset-failed
+
+- name: Init cluster inside the transient k3s-init service
+  command:
+    cmd: "systemd-run -p RestartSec=2i \
+                      -p Restart=on-failure \
+                      -E K3S_TOKEN={{ hostvars[groups['master'][0]]['token'] }} \
+                      --unit=k3s-init \
+                      k3s server {{ server_init_args }}"
+    creates: "{{ systemd_dir }}/k3s.service"
+  args:
+    warn: false  # The ansible systemd module does not support transient units
+
+- name: Verification
+  block:
+    - name: Verify that all nodes actually joined
+      command:
+        cmd: k3s kubectl get --raw /api/v1/nodes/
+        creates: "{{ systemd_dir }}/k3s.service"
+      register: nodes
+      until: nodes.rc == 0 and
+        ((nodes.stdout | from_json)['items'] |
+        json_query('[*].metadata.labels."node-role.kubernetes.io/master"') | count) == (groups['master'] | length)
+      retries: 20
+      delay: 10
+      changed_when: false
+  always:
+    - name: Kill the temporary service used for initialization
+      systemd:
+        name: k3s-init
+        state: stopped
+      failed_when: false
 
 - name: Copy K3s service file
   register: k3s_service

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -99,7 +99,7 @@
     owner: "{{ ansible_user }}"
     mode: "u=rw,g=,o="
 
-- name: Replace https://localhost:6443 by https://master-ip:6443
+- name: Configure kubectl cluster to https://{{ apiserver_endpoint }}:6443
   ansible.builtin.command: >-
     /usr/local/bin/k3s kubectl config set-cluster default
       --server=https://{{ apiserver_endpoint }}:6443

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
 - name: Clean previous runs of k3s-init
-  systemd:
+  ansible.builtin.systemd:
     name: k3s-init
     state: stopped
   failed_when: false
 
 - name: Clean previous runs of k3s-init
-  command: systemctl reset-failed k3s-init
+  ansible.builtin.command: systemctl reset-failed k3s-init
   failed_when: false
   changed_when: false
   args:
     warn: false  # The ansible systemd module does not support reset-failed
 
 - name: Init cluster inside the transient k3s-init service
-  command:
+  ansible.builtin.command:
     cmd: "systemd-run -p RestartSec=2 \
                       -p Restart=on-failure \
                       --unit=k3s-init \
@@ -25,7 +25,7 @@
 - name: Verification
   block:
     - name: Verify that all nodes actually joined (check k3s-init.service if this fails)
-      command:
+      ansible.builtin.command:
         cmd: k3s kubectl get nodes -l "node-role.kubernetes.io/master=true" -o=jsonpath="{.items[*].metadata.name}"
       register: nodes
       until: nodes.rc == 0 and (nodes.stdout.split() | length) == (groups['master'] | length)
@@ -34,7 +34,7 @@
       changed_when: false
   always:
     - name: Kill the temporary service used for initialization
-      systemd:
+      ansible.builtin.systemd:
         name: k3s-init
         state: stopped
       failed_when: false
@@ -61,17 +61,17 @@
 
 - name: Register node-token file access mode
   ansible.builtin.stat:
-    path: "{{ k3s_server_location }}/server/node-token"
+    path: "{{ k3s_server_location }}/server"
   register: p
 
 - name: Change file access node-token
   ansible.builtin.file:
-    path: "{{ k3s_server_location }}/server/node-token"
+    path: "{{ k3s_server_location }}/server"
     mode: "g+rx,o+rx"
 
 - name: Read node-token from master
   ansible.builtin.slurp:
-    path: "{{ k3s_server_location }}/server/node-token"
+    src: "{{ k3s_server_location }}/server/node-token"
   register: node_token
 
 - name: Store Master node-token
@@ -80,7 +80,7 @@
 
 - name: Restore node-token file access
   ansible.builtin.file:
-    path: "{{ k3s_server_location }}/server/node-token"
+    path: "{{ k3s_server_location }}/server"
     mode: "{{ p.stat.mode }}"
 
 - name: Create directory .kube

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -14,9 +14,9 @@
 
 - name: Init cluster inside the transient k3s-init service
   command:
-    cmd: "systemd-run -p RestartSec=2i \
+    cmd: "systemd-run -p RestartSec=2 \
                       -p Restart=on-failure \
-                      -E K3S_TOKEN={{ hostvars[groups['master'][0]]['token'] }} \
+                      -E K3S_TOKEN={{ k3s_token }} \
                       --unit=k3s-init \
                       k3s server {{ server_init_args }}"
     creates: "{{ systemd_dir }}/k3s.service"
@@ -105,7 +105,7 @@
 - name: Replace https://localhost:6443 by https://master-ip:6443
   ansible.builtin.command: >-
     /usr/local/bin/k3s kubectl config set-cluster default
-      --server=https://{{ master_ip }}:6443
+      --server=https://{{ apiserver_endpoint }}:6443
       --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true
 

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -98,10 +98,10 @@
     owner: "{{ ansible_user }}"
     mode: "u=rw,g=,o="
 
-- name: Configure kubectl cluster to https://{{ apiserver_endpoint }}:6443
+- name: Configure kubectl cluster to https://{{ apiserver_endpoint }}:{{ apiserver_port | default(6443) }}
   ansible.builtin.command: >-
     /usr/local/bin/k3s kubectl config set-cluster default
-      --server=https://{{ apiserver_endpoint }}:6443
+      --server=https://{{ apiserver_endpoint }}:{{ apiserver_port | default(6443) }}
       --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true
 

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -6,21 +6,17 @@
   failed_when: false
 
 - name: Clean previous runs of k3s-init
-  ansible.builtin.command: systemctl reset-failed k3s-init
+  ansible.builtin.command: systemctl reset-failed k3s-init  # noqa: command-instead-of-module
   failed_when: false
   changed_when: false
-  args:
-    warn: false  # The ansible systemd module does not support reset-failed
 
 - name: Init cluster inside the transient k3s-init service
   ansible.builtin.command:
     cmd: "systemd-run -p RestartSec=2 \
                       -p Restart=on-failure \
                       --unit=k3s-init \
-                      k3s server {{ server_init_args }}"
+                      k3s server {{ k3s_server_init_args }}"
     creates: "{{ systemd_dir }}/k3s.service"
-  args:
-    warn: false  # The ansible systemd module does not support transient units
 
 - name: Verification
   block:
@@ -98,7 +94,7 @@
     owner: "{{ ansible_user }}"
     mode: "u=rw,g=,o="
 
-- name: Configure kubectl cluster to https://{{ apiserver_endpoint }}:{{ apiserver_port | default(6443) }}
+- name: Configure kubectl cluster to server endpoint
   ansible.builtin.command: >-
     /usr/local/bin/k3s kubectl config set-cluster default
       --server=https://{{ apiserver_endpoint }}:{{ apiserver_port | default(6443) }}

--- a/roles/k3s/node/templates/k3s.service.j2
+++ b/roles/k3s/node/templates/k3s.service.j2
@@ -7,7 +7,7 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint }}:6443 --token {{ k3s_token }} {{ extra_agent_args | default("") }}
+ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint }}:6443 --token {{ hostvars[groups['master'][0]]['token'] | default(k3s_token) }} {{ extra_agent_args | default("") }}
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/roles/k3s/node/templates/k3s.service.j2
+++ b/roles/k3s/node/templates/k3s.service.j2
@@ -7,7 +7,7 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s agent --server https://{{ master_ip }}:6443 --token {{ hostvars[groups['master'][0]]['token'] }} {{ extra_agent_args | default("") }}
+ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint }}:6443 --token {{ k3s_token }} {{ extra_agent_args | default("") }}
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/roles/k3s/node/templates/k3s.service.j2
+++ b/roles/k3s/node/templates/k3s.service.j2
@@ -7,7 +7,7 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint }}:6443 --token {{ hostvars[groups['master'][0]]['token'] | default(k3s_token) }} {{ extra_agent_args | default("") }}
+ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint }}:{{ apiserver_port | default(6443) }} --token {{ hostvars[groups['master'][0]]['token'] | default(k3s_token) }} {{ extra_agent_args | default("") }}
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -8,6 +8,7 @@
   with_items:
     - k3s
     - k3s-node
+    - k3s-init
 
 - name: Pkill k3s container runtimes"
   register: pkill_containerd_shim_runc


### PR DESCRIPTION
This enables initializing a cluster in HA mode with an embedded DB.
https://rancher.com/docs/k3s/latest/en/installation/ha-embedded/

When multiple masters are specified in the master group, k3s-ansible will add the necessary flags during the initialization phase (i.e. --cluster-init and --server)

For the embedded HA mode to work the k3s version must be >= v1.19.1

Closes #32