### PR TITLE
Correct repo path in downloading URL

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -2,8 +2,8 @@
 
 - name: Download k3s binary x64
   get_url:
-    url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s
-    checksum: sha256:https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/sha256sum-amd64.txt
+    url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s
+    checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-amd64.txt
     dest: /usr/local/bin/k3s
     owner: root
     group: root
@@ -12,8 +12,8 @@
 
 - name: Download k3s binary arm64
   get_url:
-    url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s-arm64
-    checksum: sha256:https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/sha256sum-arm64.txt
+    url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s-arm64
+    checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-arm64.txt
     dest: /usr/local/bin/k3s
     owner: root
     group: root
@@ -25,8 +25,8 @@
 
 - name: Download k3s binary armhf
   get_url:
-    url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s-armhf
-    checksum: sha256:https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/sha256sum-arm.txt
+    url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s-armhf
+    checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-arm.txt
     dest: /usr/local/bin/k3s
     owner: root
     group: root


### PR DESCRIPTION
Fix #102, use k3s-io/k3s instead of rancher/k3s