### PR TITLE
Add Alpine Linux configuration

### DIFF
--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -1,20 +1,10 @@
 ---
 
-- name: Copy K3s service file
-  register: k3s_service
-  template:
-    src: "k3s.service.j2"
-    dest: "{{ systemd_dir }}/k3s.service"
-    owner: root
-    group: root
-    mode: 0755
-
-- name: Enable and check K3s service
-  systemd:
-    name: k3s
-    daemon_reload: yes
-    state: restarted
-    enabled: yes
+- name: Create and enable K3s service
+  include_tasks: "{{ item }}"
+  with_first_found:
+    - "prereq/{{ ansible_distribution }}.yml"
+    - "prereq/default.yml"
 
 - name: Wait for node-token
   wait_for:
@@ -61,7 +51,7 @@
 
 - name: Replace https://localhost:6443 by https://master-ip:6443
   command: >-
-    k3s kubectl config set-cluster default
+    /usr/local/bin/k3s kubectl config set-cluster default
       --server=https://{{ master_ip }}:6443
       --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true

--- a/roles/k3s/master/tasks/prereq/Alpine.yml
+++ b/roles/k3s/master/tasks/prereq/Alpine.yml
@@ -1,0 +1,30 @@
+---
+- name: Copy K3s service file
+  register: k3s_service
+  copy:
+    content: |
+      #!/sbin/openrc-run
+
+      name="k3s server"
+      command="/usr/local/bin/k3s"
+      command_args="server {{ extra_server_args | default("") }}"
+      command_background=true
+      pidfile="/run/${RC_SVCNAME}.pid"
+      output_log="/var/log/k3s.log"
+      error_log="/var/log/k3s.err"
+    dest: /etc/init.d/k3s
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Create K3s service symlink
+  file:
+    src: /etc/init.d/k3s
+    dest: /etc/runlevels/default/k3s
+    state: link
+
+- name: Enable and check K3s service
+  service:
+    name: k3s
+    state: restarted
+    enabled: yes

--- a/roles/k3s/master/tasks/prereq/default.yml
+++ b/roles/k3s/master/tasks/prereq/default.yml
@@ -1,0 +1,16 @@
+---
+- name: Copy K3s service file
+  register: k3s_service
+  template:
+    src: "k3s.service.j2"
+    dest: "{{ systemd_dir }}/k3s.service"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Enable and check K3s service
+  systemd:
+    name: k3s
+    daemon_reload: yes
+    state: restarted
+    enabled: yes

--- a/roles/k3s/node/tasks/main.yml
+++ b/roles/k3s/node/tasks/main.yml
@@ -1,16 +1,7 @@
 ---
 
-- name: Copy K3s service file
-  template:
-    src: "k3s.service.j2"
-    dest: "{{ systemd_dir }}/k3s-node.service"
-    owner: root
-    group: root
-    mode: 0755
-
-- name: Enable and check K3s service
-  systemd:
-    name: k3s-node
-    daemon_reload: yes
-    state: restarted
-    enabled: yes
+- name: Create and enable K3s service
+  include_tasks: "{{ item }}"
+  with_first_found:
+    - "prereq/{{ ansible_distribution }}.yml"
+    - "prereq/default.yml"

--- a/roles/k3s/node/tasks/prereq/Alpine.yml
+++ b/roles/k3s/node/tasks/prereq/Alpine.yml
@@ -1,0 +1,30 @@
+---
+- name: Copy K3s service file
+  register: k3s_service
+  copy:
+    content: |
+      #!/sbin/openrc-run
+
+      name="k3s agent"
+      command="/usr/local/bin/k3s"
+      command_args="agent --server https://{{ master_ip }}:6443 --token {{ hostvars[groups['master'][0]]['token'] }} {{ extra_agent_args | default("") }}"
+      command_background=true
+      pidfile="/run/${RC_SVCNAME}.pid"
+      output_log="/var/log/k3s.log"
+      error_log="/var/log/k3s.err"
+    dest: /etc/init.d/k3s
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Create K3s service symlink
+  file:
+    src: /etc/init.d/k3s
+    dest: /etc/runlevels/default/k3s
+    state: link
+
+- name: Enable and check K3s service
+  service:
+    name: k3s
+    state: restarted
+    enabled: yes

--- a/roles/k3s/node/tasks/prereq/Alpine.yml
+++ b/roles/k3s/node/tasks/prereq/Alpine.yml
@@ -28,3 +28,7 @@
     name: k3s
     state: restarted
     enabled: yes
+
+- name: lbu
+  debug:
+    msg: Remember to commit changes with 'lbu ci -d' to store the k3s passwords

--- a/roles/k3s/node/tasks/prereq/default.yml
+++ b/roles/k3s/node/tasks/prereq/default.yml
@@ -1,0 +1,15 @@
+---
+- name: Copy K3s service file
+  template:
+    src: "k3s.service.j2"
+    dest: "{{ systemd_dir }}/k3s-node.service"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Enable and check K3s service
+  systemd:
+    name: k3s-node
+    daemon_reload: yes
+    state: restarted
+    enabled: yes

--- a/roles/raspberrypi/handlers/main.yml
+++ b/roles/raspberrypi/handlers/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: reboot
   reboot:
+
+- name: lbu
+  debug:
+    msg: If you are diskless on Alpine you should commit changes with 'lbu -u' now and reboot.

--- a/roles/raspberrypi/tasks/prereq/Alpine.yml
+++ b/roles/raspberrypi/tasks/prereq/Alpine.yml
@@ -1,0 +1,29 @@
+---
+- name: Add cgroup mount point
+  lineinfile:
+    path: /etc/fstab
+    line: cgroup /sys/fs/cgroup cgroup defaults 0 0
+
+- name: Define cgroup mount points
+  copy:
+    content: |
+      mount {
+        cpuacct = /cgroup/cpuacct;
+        memory = /cgroup/memory;
+        devices = /cgroup/devices;
+        freezer = /cgroup/freezer;
+        net_cls = /cgroup/net_cls;
+        blkio = /cgroup/blkio;
+        cpuset = /cgroup/cpuset;
+        cpu = /cgroup/cpu;
+      }
+    dest: /etc/cgconfig.conf
+    mode: 0644
+
+- name: Enable cgroup via boot commandline if not already enabled
+  lineinfile:
+    path: /media/mmcblk0p1/cmdline.txt
+    backrefs: yes
+    regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
+    line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
+  notify: lbu

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -1,42 +1,5 @@
----
-- name: Disable services
-  systemd:
-    name: "{{ item }}"
-    state: stopped
-    enabled: no
-  failed_when: false
-  with_items:
-    - k3s
-    - k3s-node
-
-- name: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim-runc"
-  register: pkill_containerd_shim_runc
-  command: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim-runc"
-  changed_when: "pkill_containerd_shim_runc.rc == 0"
-  failed_when: false
-
-- name: Umount k3s filesystems
-  include_tasks: umount_with_children.yml
-  with_items:
-    - /run/k3s
-    - /var/lib/kubelet
-    - /run/netns
-    - /var/lib/rancher/k3s
-  loop_control:
-    loop_var: mounted_fs
-
-- name: Remove service files, binaries and data
-  file:
-    name: "{{ item }}"
-    state: absent
-  with_items:
-    - "{{ systemd_dir }}/k3s.service"
-    - "{{ systemd_dir }}/k3s-node.service"
-    - /etc/rancher/k3s
-    - /var/lib/rancher/k3s
-    - /var/lib/kubelet
-    - /usr/local/bin/k3s
-
-- name: daemon_reload
-  systemd:
-    daemon_reload: yes
+- name: Delete every service and binary
+  include_tasks: "{{ item }}"
+  with_first_found:
+    - "prereq/{{ ansible_distribution }}.yml"
+    - "prereq/default.yml"

--- a/roles/reset/tasks/prereq/Alpine.yml
+++ b/roles/reset/tasks/prereq/Alpine.yml
@@ -1,0 +1,28 @@
+---
+- name: Disable services
+  service:
+    name: k3s
+    state: stopped
+    enabled: no
+
+- name: Umount k3s filesystems
+  include_tasks: umount_with_children.yml
+  with_items:
+    - /run/k3s
+    - /var/lib/kubelet
+    - /run/netns
+    - /var/lib/rancher/k3s
+  loop_control:
+    loop_var: mounted_fs
+
+- name: Remove service files, binaries and data
+  file:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - /etc/init.d/k3s
+    - /etc/runlevels/default/k3s
+    - /etc/rancher/k3s
+    - /var/lib/rancher/k3s
+    - /var/lib/kubelet
+    - /usr/local/bin/k3s

--- a/roles/reset/tasks/prereq/default.yml
+++ b/roles/reset/tasks/prereq/default.yml
@@ -1,0 +1,42 @@
+---
+- name: Disable services
+  systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: no
+  failed_when: false
+  with_items:
+    - k3s
+    - k3s-node
+
+- name: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim-runc"
+  register: pkill_containerd_shim_runc
+  command: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim-runc"
+  changed_when: "pkill_containerd_shim_runc.rc == 0"
+  failed_when: false
+
+- name: Umount k3s filesystems
+  include_tasks: umount_with_children.yml
+  with_items:
+    - /run/k3s
+    - /var/lib/kubelet
+    - /run/netns
+    - /var/lib/rancher/k3s
+  loop_control:
+    loop_var: mounted_fs
+
+- name: Remove service files, binaries and data
+  file:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ systemd_dir }}/k3s.service"
+    - "{{ systemd_dir }}/k3s-node.service"
+    - /etc/rancher/k3s
+    - /var/lib/rancher/k3s
+    - /var/lib/kubelet
+    - /usr/local/bin/k3s
+
+- name: daemon_reload
+  systemd:
+    daemon_reload: yes

--- a/roles/reset/tasks/umount_with_children.yml
+++ b/roles/reset/tasks/umount_with_children.yml
@@ -2,8 +2,6 @@
 - name: Get the list of mounted filesystems
   shell: set -o pipefail && cat /proc/mounts | awk '{ print $2}' | grep -E "^{{ mounted_fs }}"
   register: get_mounted_filesystems
-  args:
-    executable: /bin/bash
   failed_when: false
   changed_when: get_mounted_filesystems.stdout | length > 0
 


### PR DESCRIPTION
This adds support for Alpine Linux. There is a tricky question about how to best handle reboot because it depends on how one is using Alpine. If it is diskless as many do, then reboot cannot be done before committing with `lbu`. 

The approach I chose is to just notify the developer. This allows to manually check if the installation is correct before committing and rebooting. After reboot, the service starts and k3s is already working correctly without a second run of the playbook.

This should close #69 , or at least provide a good example of how to do it.