### PR TITLE
Added (airgap) images as part of the download role to provide full coverage of a k3s installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,21 @@ on processor architecture:
 
 ## System requirements
 
-Deployment environment must have Ansible 2.4.0+
-Master and nodes must have passwordless SSH access
+- Deployment environment must have Ansible 2.4.0+
+- Master and nodes must have passwordless SSH access
+- For an airgap installation (no outbound internet access on nodes), all asset files for your CPU architecture from `https://github.com/k3s-io/k3s/releases/tag/{k3s_version}` should reside on an HTTP share within your private environment, accessible by all target nodes. For some super quick ways to to share a folder via HTTP, check out [this post](https://unix.stackexchange.com/questions/32182/simple-command-line-http-server). Any ordinary HTTP server will work as well.
+
+    Example content for the HTTP folder when choosing the `amd64` architecture and k3s version `v1.20.2+k3s1` (notice the subfolder set to the version name):
+    - `v1.20.2+k3s1` (the subfolder containing the assets below)
+    - `v1.20.2+k3s1/k3s`
+    - `v1.20.2+k3s1/k3s-airgap-images-amd64.tar`
+    - `v1.20.2+k3s1/sha256sum-amd64.txt`
+
+    For `arm64` respectively:
+    - `v1.20.2+k3s1` (the subfolder containing the assets below)
+    - `v1.20.2+k3s1/k3s-arm64`
+    - `v1.20.2+k3s1/k3s-airgap-images-arm64.tar`
+    - `v1.20.2+k3s1/sha256sum-arm64.txt`
 
 ## Usage
 
@@ -43,7 +56,7 @@ master
 node
 ```
 
-If needed, you can also edit `inventory/my-cluster/group_vars/all.yml` to match your environment.
+If needed, you can also edit `inventory/my-cluster/group_vars/all.yml` to match your environment. For an airgap installation (see requirements above), please edit `remote_repo_url` to point to your webserver root *containing* the k3s version *subfolder*, e.g. `http://internalurlorip/k3s-binaries-and-images`. Don't point this directly to the version subfolder itself (-> point it to the *parent* folder), and don't include a trailing `/`.
 
 Start provisioning of the cluster using the following command:
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ master
 node
 ```
 
-If needed, you can also edit `inventory/my-cluster/group_vars/all.yml` to match your environment. For an airgap installation (see requirements above), please edit `remote_repo_url` to point to your webserver root *containing* the k3s version *subfolder*, e.g. `http://internalurlorip/k3s-binaries-and-images`. Don't point this directly to the version subfolder itself (-> point it to the *parent* folder), and don't include a trailing `/`.
+If needed, you can also edit `inventory/my-cluster/group_vars/all.yml` to match your environment. For an airgap installation (see requirements above), please set `airgapped` to `true` and change `remote_repo_url` to point to your webserver root *containing* the k3s version *subfolder*, e.g. `http://internalurlorip/k3s-binaries-and-images`. Don't point this directly to the version subfolder itself (-> point it to the *parent* folder), and don't include a trailing `/`.
 
 Start provisioning of the cluster using the following command:
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ on processor architecture:
 - Master and nodes must have passwordless SSH access
 - For an airgap installation (no outbound internet access on nodes), all asset files for your CPU architecture from `https://github.com/k3s-io/k3s/releases/tag/{k3s_version}` should reside on an HTTP share within your private environment, accessible by all target nodes. For some super quick ways to to share a folder via HTTP, check out [this post](https://unix.stackexchange.com/questions/32182/simple-command-line-http-server). Any ordinary HTTP server will work as well.
 
-    Example content for the HTTP folder when choosing the `amd64` architecture and k3s version `v1.20.2+k3s1` (notice the subfolder set to the version name):
-    - `v1.20.2+k3s1` (the subfolder containing the assets below)
-    - `v1.20.2+k3s1/k3s`
-    - `v1.20.2+k3s1/k3s-airgap-images-amd64.tar`
-    - `v1.20.2+k3s1/sha256sum-amd64.txt`
+    Example content for the HTTP folder when choosing the `amd64` architecture and k3s version `v1.27.2+k3s1` (notice the subfolder set to the version name):
+    - `v1.27.2+k3s1` (the subfolder containing the assets below)
+    - `v1.27.2+k3s1/k3s`
+    - `v1.27.2+k3s1/k3s-airgap-images-amd64.tar`
+    - `v1.27.2+k3s1/sha256sum-amd64.txt`
 
     For `arm64` respectively:
-    - `v1.20.2+k3s1` (the subfolder containing the assets below)
-    - `v1.20.2+k3s1/k3s-arm64`
-    - `v1.20.2+k3s1/k3s-airgap-images-arm64.tar`
-    - `v1.20.2+k3s1/sha256sum-arm64.txt`
+    - `v1.27.2+k3s1` (the subfolder containing the assets below)
+    - `v1.27.2+k3s1/k3s-arm64`
+    - `v1.27.2+k3s1/k3s-airgap-images-arm64.tar`
+    - `v1.27.2+k3s1/sha256sum-arm64.txt`
 
 ## Usage
 

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,5 +1,6 @@
 ---
-k3s_version: v1.17.5+k3s1
+remote_repo_url: https://github.com/k3s-io/k3s/releases/download
+k3s_version: v1.20.2+k3s1
 ansible_user: debian
 systemd_dir: /etc/systemd/system
 master_ip: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}"

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -6,3 +6,4 @@ master_ip: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['m
 extra_server_args: ""
 extra_agent_args: ""
 remote_repo_url: https://github.com/k3s-io/k3s/releases/download
+airgapped: false

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-k3s_version: v1.22.3+k3s1
+k3s_version: v1.27.2+k3s1
 ansible_user: debian
 systemd_dir: /etc/systemd/system
 master_ip: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}"

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -1,19 +1,36 @@
 ---
+- name: Create target image directory for k3s
+  file:
+    path: /var/lib/rancher/k3s/agent/images
+    state: directory
+    mode: 0744
+    group: root
+    owner: root
 
 - name: Download k3s binary x64
   get_url:
-    url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s
-    checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-amd64.txt
+    url: "{{ remote_repo_url }}/{{ k3s_version }}/k3s"
+    checksum: "sha256:{{ remote_repo_url }}/{{ k3s_version }}/sha256sum-amd64.txt"
     dest: /usr/local/bin/k3s
     owner: root
     group: root
     mode: 0755
   when: ansible_facts.architecture == "x86_64"
 
+- name: Download k3s airgap images x64
+  get_url:
+    url: "{{ remote_repo_url }}/{{ k3s_version }}/k3s-airgap-images-amd64.tar"
+    checksum: "sha256:{{ remote_repo_url }}/{{ k3s_version }}/sha256sum-amd64.txt"
+    dest: /var/lib/rancher/k3s/agent/images/k3s-airgap-images-amd64.tar
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_facts.architecture == "x86_64"
+
 - name: Download k3s binary arm64
   get_url:
-    url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s-arm64
-    checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-arm64.txt
+    url: "{{ remote_repo_url }}/{{ k3s_version }}/k3s-arm64"
+    checksum: "sha256:{{ remote_repo_url }}/{{ k3s_version }}/sha256sum-arm64.txt"
     dest: /usr/local/bin/k3s
     owner: root
     group: root
@@ -23,14 +40,39 @@
         ansible_facts.userspace_bits == "64" ) or
       ansible_facts.architecture is search("aarch64")
 
+- name: Download k3s airgap images arm64
+  get_url:
+    url: "{{ remote_repo_url }}/{{ k3s_version }}/k3s-airgap-images-arm64.tar"
+    checksum: "sha256:{{ remote_repo_url }}/{{ k3s_version }}/sha256sum-arm64.txt"
+    dest: /var/lib/rancher/k3s/agent/images/k3s-airgap-images-arm64.tar
+    owner: root
+    group: root
+    mode: 0644
+  when:
+    - ( ansible_facts.architecture is search("arm") and
+        ansible_facts.userspace_bits == "64" ) or
+      ansible_facts.architecture is search("aarch64")
+
 - name: Download k3s binary armhf
   get_url:
-    url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s-armhf
-    checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-arm.txt
+    url: "{{ remote_repo_url }}/{{ k3s_version }}/k3s-armhf"
+    checksum: "sha256:{{ remote_repo_url }}/{{ k3s_version }}/sha256sum-arm.txt"
     dest: /usr/local/bin/k3s
     owner: root
     group: root
     mode: 0755
+  when:
+    - ansible_facts.architecture is search("arm")
+    - ansible_facts.userspace_bits == "32"
+
+- name: Download k3s airgap images armhf
+  get_url:
+    url: "{{ remote_repo_url }}/{{ k3s_version }}/k3s-airgap-images-arm.tar"
+    checksum: "sha256:{{ remote_repo_url }}/{{ k3s_version }}/sha256sum-arm.txt"
+    dest: /var/lib/rancher/k3s/agent/images/k3s-airgap-images-arm.tar
+    owner: root
+    group: root
+    mode: 0644
   when:
     - ansible_facts.architecture is search("arm")
     - ansible_facts.userspace_bits == "32"

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -25,7 +25,9 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_facts.architecture == "x86_64"
+  when:
+    - ansible_facts.architecture == "x86_64"
+    - airgapped
 
 - name: Download k3s binary arm64
   get_url:
@@ -52,6 +54,7 @@
     - ( ansible_facts.architecture is search("arm") and
         ansible_facts.userspace_bits == "64" ) or
       ansible_facts.architecture is search("aarch64")
+    - airgapped
 
 - name: Download k3s binary armhf
   get_url:
@@ -76,3 +79,4 @@
   when:
     - ansible_facts.architecture is search("arm")
     - ansible_facts.userspace_bits == "32"
+    - airgapped


### PR DESCRIPTION
Even if internet access on the target nodes is available, the images were not part of the Ansible rollout itself. Since they are pre-packaged and available from k3s for all versions already, I added them. This has the benefit of making an airgap installation via Ansible very easy, too.

Detailed instructions for an airgap installation are included as well, plus I bumped the sample version up to the latest `v1.20.2+k3s1`.

Addresses #94 
Fixes #108 

Cheers,
Peter