### PR TITLE
Reorganize the filesystem umount order.

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -33,8 +33,8 @@
     - "{{ systemd_dir }}/k3s.service"
     - "{{ systemd_dir }}/k3s-node.service"
     - /etc/rancher/k3s
-    - /var/lib/rancher/k3s
     - /var/lib/kubelet
+    - /var/lib/rancher/k3s
     - /usr/local/bin/k3s
 
 - name: daemon_reload

--- a/roles/reset/tasks/umount_with_children.yml
+++ b/roles/reset/tasks/umount_with_children.yml
@@ -12,4 +12,4 @@
     path: "{{ item }}"
     state: unmounted
   with_items:
-    "{{ get_mounted_filesystems.stdout_lines }}"
+    "{{ get_mounted_filesystems.stdout_lines | reverse | list }}"


### PR DESCRIPTION
* Clean /var/lib/kubelet before /var/lib/rancher/k3s.
* Umount the filesystem tree in reverse order, to ensure the root
  is umounted last.