### PR TITLE
Abort the play on all hosts if any error happens in the k3s_cluster building process

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,7 @@
 ---
 
 - hosts: k3s_cluster
+  any_errors_fatal: true
   gather_facts: yes
   become: yes
   roles:


### PR DESCRIPTION
When I tried to run the playbook, the download process failed because of some network issues. Since only some of the nodes can download the requirements for k3s, the cluster setup tasks will fail. Instead of stopping the task manually, I think using `any_errors_fatal: true` in the k3s_cluster building process will be better.