### PR TITLE
Add stub for ansible-galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,3 @@
+---
+
+galaxy_info:


### PR DESCRIPTION
When using a large number of different roles from 3rd party authors, it is more convenient to download it with ansible-galaxy. Now we use this role as git submodule with a link to your repository. This one line in meta/main.yml is enough for galaxy to consider repository as valid "role".


Example requirements.yaml

```yaml
roles:
  - name: k3s-io.k3s-ansible
    src: https://github.com/hodorov/k3s-ansible.git
    version: master # May use git tag, git branch name, git commit hash
```

Then download roles with

```sh
ansible-galaxy install -r requirements.yaml
```

Example playbook
```yaml
- hosts: k3s_masters
  roles:
    - role: k3s-io.k3s-ansible/roles/prereq
    - role: k3s-io.k3s-ansible/roles/download
      vars:
        k3s_version: v1.21.1+k3s1
    - role: k3s-io.k3s-ansible/roles/k3s/master
```