### PR TITLE
Random node-id

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -4,4 +4,4 @@ ansible_user: debian
 systemd_dir: /etc/systemd/system
 master_ip: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}"
 extra_server_args: ""
-extra_agent_args: ""
+extra_agent_args: "extra_agent_args: "--with-node-id node-$(openssl rand -base64 12)""

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -4,4 +4,4 @@ ansible_user: debian
 systemd_dir: /etc/systemd/system
 master_ip: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}"
 extra_server_args: ""
-extra_agent_args: "extra_agent_args: "--with-node-id node-$(openssl rand -base64 12)""
+extra_agent_args: "--with-node-id node-$(openssl rand -base64 12)"


### PR DESCRIPTION
This solves the issue of devices not connecting to the cluster if they have the same hostname as another node on the cluster.

See: https://github.com/k3s-io/k3s-ansible/issues/135

@reviewer, should `--with-node-id node-$(openssl rand -base64 12)` be in [all.yml](https://github.com/k3s-io/k3s-ansible/blob/master/inventory/sample/group_vars/all.yml#L7) or [roles/k3s/node/templates/k3s.service.j2](https://github.com/k3s-io/k3s-ansible/blob/master/roles/k3s/node/templates/k3s.service.j2#L10). All.yml is easier for users to remove if it's not needed, k3s.service.j looks cleaner.