### PR TITLE
add SELinux support

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -5,3 +5,8 @@ systemd_dir: /etc/systemd/system
 master_ip: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}"
 extra_server_args: ""
 extra_agent_args: ""
+
+# Selinux
+k3s_selinux_enable: true
+k3s_selinux_release: v0.3.latest.0
+k3s_selinux_package: k3s-selinux-0.3-0

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -1,8 +1,25 @@
 ---
-- name: Set SELinux to disabled state
+
+- name: Import variables specific to distribution
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
+    - "vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+    - "vars/{{ ansible_facts['distribution'] }}.yml"
+    - "vars/default.yml"
+
+- name: "Install k3s-selinux package"
+  yum:
+    name: "{{k3s_selinux_packages}}"
+    disable_gpg_check: true
+    state: installed
+  when:
+    - k3s_selinux_enable
+
+- name: Set SELinux state
   selinux:
-    state: disabled
-  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
+    policy: "targeted"
+    state: "{{ 'enforcing' if k3s_selinux_enable else 'disabled' }}"
 
 - name: Enable IPv4 forwarding
   sysctl:

--- a/roles/prereq/vars/RedHat-7.yml
+++ b/roles/prereq/vars/RedHat-7.yml
@@ -1,0 +1,3 @@
+---
+k3s_selinux_packages:
+  - "https://github.com/k3s-io/k3s-selinux/releases/download/{{k3s_selinux_release}}/{{k3s_selinux_package}}.el7.noarch.rpm"

--- a/roles/prereq/vars/RedHat-8.yml
+++ b/roles/prereq/vars/RedHat-8.yml
@@ -1,0 +1,3 @@
+---
+k3s_selinux_packages:
+  - "https://github.com/k3s-io/k3s-selinux/releases/download/{{k3s_selinux_release}}/{{k3s_selinux_package}}.el7.noarch.rpm"

--- a/roles/prereq/vars/RedHat-8.yml
+++ b/roles/prereq/vars/RedHat-8.yml
@@ -1,3 +1,3 @@
 ---
 k3s_selinux_packages:
-  - "https://github.com/k3s-io/k3s-selinux/releases/download/{{k3s_selinux_release}}/{{k3s_selinux_package}}.el7.noarch.rpm"
+  - "https://github.com/k3s-io/k3s-selinux/releases/download/{{k3s_selinux_release}}/{{k3s_selinux_package}}.el8.noarch.rpm"

--- a/roles/prereq/vars/default.yml
+++ b/roles/prereq/vars/default.yml
@@ -1,0 +1,2 @@
+---
+k3s_selinux_enable: false


### PR DESCRIPTION
Download and install SElinux policy for k3s on Red Hat and CentOS machines.

Fixes:
* https://github.com/k3s-io/k3s-ansible/issues/98