### PR TITLE
use full path for k3s binary

### DIFF
--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -61,7 +61,7 @@
 
 - name: Replace https://localhost:6443 by https://master-ip:6443
   command: >-
-    k3s kubectl config set-cluster default
+    /usr/local/bin/k3s kubectl config set-cluster default
       --server=https://{{ master_ip }}:6443
       --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true


### PR DESCRIPTION
Don't rely on `/usr/local/bin` being in the `PATH`.