### PR TITLE
Fix omissions and errors in the reset role that leave artifacts after successful reset.yml playbook run

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,7 +1,18 @@
 ---
 k3s_version: v1.22.3+k3s1
 ansible_user: debian
-systemd_dir: /etc/systemd/system
 master_ip: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}"
 extra_server_args: ""
 extra_agent_args: ""
+
+# Services information
+systemd_dir: /etc/systemd/system
+
+k3s_services:
+  - k3s
+  - k3s-node
+
+k3s_service_file_extensions:
+  - service
+  - service.env
+

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -5,6 +5,8 @@ master_ip: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['m
 extra_server_args: ""
 extra_agent_args: ""
 
+k3s_server_location: /var/lib/rancher/k3s
+
 # Services information
 systemd_dir: /etc/systemd/system
 

--- a/roles/k3s/master/defaults/main.yml
+++ b/roles/k3s/master/defaults/main.yml
@@ -1,2 +1,0 @@
----
-k3s_server_location: /var/lib/rancher/k3s

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -59,21 +59,31 @@
     owner: "{{ ansible_user }}"
     mode: "u=rw,g=,o="
 
+- name: Copy k3s.sh for symlink'd commands
+  register: k3s_symlink
+  template:
+    src: "k3s.sh.j2"
+    dest: "/usr/local/bin/k3s.sh"
+    owner: root
+    group: root
+    mode: 0755
+  when:
+    - k3s_server_location is defined
+    - k3s_server_location != '/var/lib/rancher/k3s'
+
+- name: Create symlink'd commands (kubectl, crictl)
+  file:
+    src: "{{ '/usr/local/bin/k3s.sh' if k3s_server_location != '/var/lib/rancher/k3s' else '/usr/local/bin/k3s' | default('/usr/local/bin/k3s') }}"
+    dest: "/usr/local/bin/{{ item }}"
+    state: link
+  with_items:
+    - kubectl
+    - crictl
+
 - name: Replace https://localhost:6443 by https://master-ip:6443
   command: >-
-    k3s kubectl config set-cluster default
+    /usr/local/bin/kubectl config set-cluster default
       --server=https://{{ master_ip }}:6443
       --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true
 
-- name: Create kubectl symlink
-  file:
-    src: /usr/local/bin/k3s
-    dest: /usr/local/bin/kubectl
-    state: link
-
-- name: Create crictl symlink
-  file:
-    src: /usr/local/bin/k3s
-    dest: /usr/local/bin/crictl
-    state: link

--- a/roles/k3s/master/templates/k3s.sh.j2
+++ b/roles/k3s/master/templates/k3s.sh.j2
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# k3s.sh is used to supply the --data-dir argument to k3s for symlink'd commands.
+# Note: this file is only present when k3s_server_location is defined.
+
+K3S_BIN="/usr/local/bin/k3s"
+DATA_DIR="{{ k3s_server_location }}"
+
+BASENAME="${0##*/}"
+
+if [ -z "${DATA_DIR}" ]
+then
+	echo "k3s.sh: DATA_DIR is not set.  Something went wrong with the ansible installation." 1>&2
+	exit 255
+fi
+
+if [ "${BASENAME}" = "k3s.sh" ]
+then
+	"${K3S_BIN}" --data-dir "${DATA_DIR}" "${@}"
+else
+	"${K3S_BIN}" --data-dir "${DATA_DIR}" "${BASENAME}" "${@}"
+fi
+

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -188,6 +188,12 @@
     - /usr/local/bin/k3s-killall.sh
     - /usr/local/bin/k3s-uninstall.sh
 
+- name: Remove ~{{ ansible_user }}/.kube/config
+  file:
+    path: "~{{ ansible_user }}/.kube/config"
+    state: absent
+  when: inventory_hostname in groups['master']
+
 - name: Remove package k3s-selinux
   yum:
     name: k3s-selinux

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -184,6 +184,7 @@
     - "{{ k3s_server_location if inventory_hostname in groups['master'] else '/var/lib/rancher/k3s' | default('/var/lib/rancher/k3s') }}"
     - /var/lib/kubelet
     - /usr/local/bin/k3s
+    - /usr/local/bin/k3s.sh
     - /usr/local/bin/k3s-killall.sh
     - /usr/local/bin/k3s-uninstall.sh
 

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -104,7 +104,7 @@
 # iptables-save | grep -v KUBE- | grep -v CNI- | iptables-restore
 # TODO: Replace with appropriate ansible module
 #
-- name: Get list of KUBE- chains
+- name: Remove KUBE and CNI chains from iptables
   register: iptables_save_restore
   shell: iptables-save | egrep -v '(KUBE|CNI)-' | iptables-restore
 

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -22,13 +22,26 @@
 
 #
 # killtree $({ set +x; } 2>/dev/null; getshims; set -x)
+# TODO: Why is this different from k3s servers?
+#
+- name: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim"
+  register: pkill_containerd_shim
+  command: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim"
+  when: inventory_hostname not in groups['master']
+  changed_when: "pkill_containerd_shim.rc == 0"
+  failed_when: false
+
+#
+# killtree $({ set +x; } 2>/dev/null; getshims; set -x)
 #
 - name: pkill -9 -f "{{ k3s_server_location }}/data/[^/]+/bin/containerd-shim"
   register: pkill_containerd_shim
   command: pkill -9 -f "{{ k3s_server_location }}/data/[^/]+/bin/containerd-shim"
+  when: inventory_hostname in groups['master']
   changed_when: "pkill_containerd_shim.rc == 0"
   failed_when: false
 
+#
 #
 # do_unmount_and_remove [the list]
 #
@@ -36,7 +49,7 @@
   include_tasks: umount_with_children.yml
   loop:
     - /run/k3s
-    - "{{ k3s_server_location }}"
+    - "{{ k3s_server_location if inventory_hostname in groups['master'] else '/var/lib/rancher/k3s' | default('/var/lib/rancher/k3s') }}"
     - /var/lib/kubelet/pods
     - /var/lib/kubelet/plugins
     - /run/netns/cni-
@@ -168,7 +181,7 @@
     - /etc/rancher/k3s
     - /run/k3s
     - /run/flannel
-    - "{{ k3s_server_location }}"
+    - "{{ k3s_server_location if inventory_hostname in groups['master'] else '/var/lib/rancher/k3s' | default('/var/lib/rancher/k3s') }}"
     - /var/lib/kubelet
     - /usr/local/bin/k3s
     - /usr/local/bin/k3s-killall.sh

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -36,7 +36,7 @@
   include_tasks: umount_with_children.yml
   loop:
     - /run/k3s
-    - /var/lib/rancher/k3s
+    - "{{ k3s_server_location }}"
     - /var/lib/kubelet/pods
     - /var/lib/kubelet/plugins
     - /run/netns/cni-
@@ -168,7 +168,7 @@
     - /etc/rancher/k3s
     - /run/k3s
     - /run/flannel
-    - /var/lib/rancher/k3s
+    - "{{ k3s_server_location }}"
     - /var/lib/kubelet
     - /usr/local/bin/k3s
     - /usr/local/bin/k3s-killall.sh

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -97,7 +97,7 @@
 
 - name: Remove CNI files
   file:
-    name: /var/lib/cni
+    path: /var/lib/cni
     state: absent
 
 #
@@ -135,7 +135,7 @@
 #
 - name: Remove service files
   file:
-    name: "{{ systemd_dir }}/{{ item }}"
+    path: "{{ systemd_dir }}/{{ item }}"
     state: absent
   loop: "{{ k3s_services | product(k3s_service_file_extensions) | map('join', '.') }}"
 
@@ -157,7 +157,7 @@
 - name: Command files
   register: stat_command_files
   stat:
-    name: "/usr/local/bin/{{ item }}"
+    path: "/usr/local/bin/{{ item }}"
   loop:
     - kubectl
     - crictl
@@ -165,7 +165,7 @@
 
 - name: Remove command files
   file:
-    name: "{{ item.stat.path }}"
+    path: "{{ item.stat.path }}"
     state: absent
   when: (item.stat.exists | default(false)) and (item.stat.islnk | default(false))
   loop: "{{ stat_command_files.results }}"
@@ -175,7 +175,7 @@
 # Remove files and directories
 - name: Remove files, binaries and data
   file:
-    name: "{{ item }}"
+    path: "{{ item }}"
     state: absent
   loop:
     - /etc/rancher/k3s

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -1,42 +1,198 @@
 ---
+
+# TODO: Should we use k3s-uninstall.sh from https://get/k3s.io instead so that
+#       we don't have to track the updates in the future?
+
+###########################
+# Start of k3s-killall.sh #
+###########################
+
+#
+# for service in /etc/systemd/system/k3s*.service; do
+#    [ -s $service ] && systemctl stop $(basename $service)
+# done
+#
 - name: Disable services
   systemd:
     name: "{{ item }}"
     state: stopped
     enabled: no
   failed_when: false
-  with_items:
-    - k3s
-    - k3s-node
+  loop: "{{ k3s_services }}"
 
-- name: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim-runc"
-  register: pkill_containerd_shim_runc
-  command: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim-runc"
-  changed_when: "pkill_containerd_shim_runc.rc == 0"
+#
+# killtree $({ set +x; } 2>/dev/null; getshims; set -x)
+#
+- name: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim"
+  register: pkill_containerd_shim
+  command: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim"
+  changed_when: "pkill_containerd_shim.rc == 0"
   failed_when: false
 
-- name: Umount k3s filesystems
+#
+# do_unmount_and_remove [the list]
+#
+- name: Umount k3s filesystems and remove mount points
   include_tasks: umount_with_children.yml
-  with_items:
+  loop:
     - /run/k3s
-    - /var/lib/kubelet
-    - /run/netns
     - /var/lib/rancher/k3s
+    - /var/lib/kubelet/pods
+    - /var/lib/kubelet/plugins
+    - /run/netns/cni-
   loop_control:
     loop_var: mounted_fs
 
-- name: Remove service files, binaries and data
+#
+# Remove CNI namespaces
+# ip netns show 2> /dev/null | grep cni- | xargs -r -t -n 1 ip netns delete
+#
+- name: Show CNI namespaces
+  register: ip_netns_show
+  command: ip -j netns show master cni0
+
+- name: Remove CNI namespaces
+  command: ip netns delete {{ item }}
+  loop: "{{ ip_netns_show.stdout | from_json | json_query('[*].name') }}"
+
+#
+# Remove CNI interfaces
+# ip link show 2>/dev/null | grep 'master cni0'
+#
+# BUG: Possible bug in ip-link(8).
+# "ip -j link show master cni0" exits 255 when cni0 does not exist where
+# "ip -j netns show master cni0" returns "[ ]", which is preferred.
+#
+- name: Get list of network interface(s) that match 'master cni0'
+  register: ip_link_show
+  shell: ip -j link show master cni0 || echo "[ ]"
+
+- name: Remove CNI interfaces
+  command: ip link delete {{ item }}
+  loop: "{{ ip_link_show.stdout | from_json | json_query('[*].ifname') }}"
+
+#
+# Remove other interfaces and files
+#
+- name: Remove other interfaces
+  command: ip link delete {{ item }}
+  when: item in ansible_interfaces
+  loop:
+    - cni0
+    - flannel.1
+    - flannel-v6.1
+
+- name: Remove CNI files
   file:
-    name: "{{ item }}"
+    name: /var/lib/cni
     state: absent
-  with_items:
-    - /usr/local/bin/k3s
-    - "{{ systemd_dir }}/k3s.service"
-    - "{{ systemd_dir }}/k3s-node.service"
-    - /etc/rancher/k3s
-    - /var/lib/kubelet
-    - /var/lib/rancher/k3s
+
+#
+# iptables-save | grep -v KUBE- | grep -v CNI- | iptables-restore
+# TODO: Replace with appropriate ansible module
+#
+- name: Get list of KUBE- chains
+  register: iptables_save_restore
+  shell: iptables-save | egrep -v '(KUBE|CNI)-' | iptables-restore
+
+#########################
+# End of k3s-killall.sh #
+#########################
+
+#
+# systemctl disable k3s
+# systemctl reset-failed k3s
+# systemctl daemon-reload
+#
+- name: Disable services
+  systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: no
+  failed_when: false
+  loop: "{{ k3s_services }}"
 
 - name: daemon_reload
   systemd:
     daemon_reload: yes
+
+#
+# rm -f /etc/systemd/system/k3s.service
+# rm -f /etc/systemd/system/k3s.service.env
+#
+- name: Remove service files
+  file:
+    name: "{{ systemd_dir }}/{{ item }}"
+    state: absent
+  loop: "{{ k3s_services | product(k3s_service_file_extensions) | map('join', '.') }}"
+
+#
+# if (ls /etc/systemd/system/k3s*.service || ls /etc/init.d/k3s*) >/dev/null 2>&1; then
+#     set +x; echo 'Additional k3s services installed, skipping uninstall of k3s'; set -x
+#    exit
+# fi
+#
+# Should this be done rather than focusing on a discrete list of services (k3s_services)?
+
+#
+# for cmd in kubectl crictl ctr; do
+#    if [ -L /usr/local/bin/$cmd ]; then
+#        rm -f /usr/local/bin/$cmd
+#    fi
+# done
+#
+- name: Command files
+  register: stat_command_files
+  stat:
+    name: "/usr/local/bin/{{ item }}"
+  loop:
+    - kubectl
+    - crictl
+    - ctr
+
+- name: Remove command files
+  file:
+    name: "{{ item.stat.path }}"
+    state: absent
+  when: (item.stat.exists | default(false)) and (item.stat.islnk | default(false))
+  loop: "{{ stat_command_files.results }}"
+  loop_control: 
+    label: "{{ item.item }}"
+
+# Remove files and directories
+- name: Remove files, binaries and data
+  file:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/rancher/k3s
+    - /run/k3s
+    - /run/flannel
+    - /var/lib/rancher/k3s
+    - /var/lib/kubelet
+    - /usr/local/bin/k3s
+    - /usr/local/bin/k3s-killall.sh
+    - /usr/local/bin/k3s-uninstall.sh
+
+- name: Remove package k3s-selinux
+  yum:
+    name: k3s-selinux
+    state: remove
+  when: ansible_pkg_mgr == "yum"
+
+- name: Remove package k3s-selinux
+  zypper:
+    name: k3s-selinux
+    state: remove
+  when: ansible_pkg_mgr == "zypper"
+
+- name: Remove yum repo files
+  shell: 'rm -f /etc/yum.repos.d/rancher-k3s-common*.repo'
+  register: remove_repo_files
+  when: ansible_pkg_mgr == "yum"
+
+- name: Remove zypper repo files
+  shell: 'rm -f /etc/zypp/repos.d/rancher-k3s-common*.repo'
+  register: remove_repo_files
+  when: ansible_pkg_mgr == "zypper"
+

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -23,9 +23,9 @@
 #
 # killtree $({ set +x; } 2>/dev/null; getshims; set -x)
 #
-- name: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim"
+- name: pkill -9 -f "{{ k3s_server_location }}/data/[^/]+/bin/containerd-shim"
   register: pkill_containerd_shim
-  command: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim"
+  command: pkill -9 -f "{{ k3s_server_location }}/data/[^/]+/bin/containerd-shim"
   changed_when: "pkill_containerd_shim.rc == 0"
   failed_when: false
 

--- a/roles/reset/tasks/umount_with_children.yml
+++ b/roles/reset/tasks/umount_with_children.yml
@@ -14,3 +14,10 @@
     state: unmounted
   with_items:
     "{{ get_mounted_filesystems.stdout_lines | reverse | list }}"
+
+- name: Remove mountpoints
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items: "{{ get_mounted_filesystems.stdout_lines | reverse | list }}"
+


### PR DESCRIPTION
The current **reset** role does not remove all network artifacts (#159).  I updated the **reset** role to perform the same actions in the same order as **k3s-uninstall.sh** as provided by https://get.k3s.io.  I used v1.22.4+k3s1 as the reference.