### PR TITLE
Added bullseye to Raspbian fact conditional list

### DIFF
--- a/roles/raspberrypi/tasks/main.yml
+++ b/roles/raspberrypi/tasks/main.yml
@@ -31,7 +31,7 @@
   when:
     - ansible_facts.architecture is search("aarch64")
     - raspberry_pi|default(false)
-    - ansible_facts.lsb.description|default("") is match("Debian.*buster")
+    - ansible_facts.lsb.description|default("") is match("Debian.*buster") or ansible_facts.lsb.description|default("") is match("Debian.*bullseye")
 
 - name: Set detected_distribution_major_version
   set_fact:


### PR DESCRIPTION
Latest versions of Raspbian are based on Bullseye. I added "bullseye" to the conditional that sets the Raspbian fact.