### PR TITLE
Add requirements.yml for AWX/Tower

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.general


### PR DESCRIPTION
Running this playbook in AWX/Tower is impossible without providing a requirement for community.general. This PR adds the required file.