### PR TITLE
Added ansible.posix to collections requirements.yml file

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
   - name: community.general
+  - name: ansible.posix


### PR DESCRIPTION
`roles/prereq/tasks/main.yml` requires `selinux` module which is a part of `ansible.posix` collection. Hence, adding `ansible.posix` to `collections/requirements.yml` file.