### PR TITLE
Add --with-node-id to prevent colliding names

### DIFF
--- a/roles/k3s/node/templates/k3s.service.j2
+++ b/roles/k3s/node/templates/k3s.service.j2
@@ -7,7 +7,7 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s agent --server https://{{ master_ip }}:6443 --token {{ hostvars[groups['master'][0]]['token'] }} {{ extra_agent_args | default("") }}
+ExecStart=/usr/local/bin/k3s agent --server https://{{ master_ip }}:6443 --with-node-id --token {{ hostvars[groups['master'][0]]['token'] }} {{ extra_agent_args | default("") }}
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
Noticed that, when running on a cluster of raspberry pis running Ubuntu 20 LTS, all 3 nodes would attempt to use "ubuntu" as their name resulting in the cluster failing to start. 

Fixed by adding --with-node-id to the exec start command.  