### PR TITLE
Make apiserver port user-configurable

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -7,9 +7,12 @@ systemd_dir: /etc/systemd/system
 # apiserver endpoint to all masters here. This default value is only suitable
 # for a non-HA setup, if used in a HA setup, it will not protect you if the
 # first node fails.
-# Also you should define k3s_token so that masters can talk together securely
 
 apiserver_endpoint: "{{ hostvars[groups['master'][0]]['ansible_host'] | default(groups['master'][0]) }}"
+apiserver_port: 6443
+
+# Also you should define k3s_token so that masters can talk together securely
+
 # k3s_token: "mysupersecuretoken"
 
 extra_server_args: ""

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Download k3s binary x64
-  get_url:
+  ansible.builtin.get_url:
     url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s
     checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-amd64.txt
     dest: /usr/local/bin/k3s
@@ -11,7 +11,7 @@
   when: ansible_facts.architecture == "x86_64"
 
 - name: Download k3s binary arm64
-  get_url:
+  ansible.builtin.get_url:
     url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s-arm64
     checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-arm64.txt
     dest: /usr/local/bin/k3s
@@ -24,7 +24,7 @@
       ansible_facts.architecture is search("aarch64")
 
 - name: Download k3s binary armhf
-  get_url:
+  ansible.builtin.get_url:
     url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s-armhf
     checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-arm.txt
     dest: /usr/local/bin/k3s

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -98,10 +98,10 @@
     owner: "{{ ansible_user }}"
     mode: "u=rw,g=,o="
 
-- name: Configure kubectl cluster to https://{{ apiserver_endpoint }}:6443
+- name: Configure kubectl cluster to https://{{ apiserver_endpoint }}:{{ apiserver_port | default(6443) }}
   command: >-
     k3s kubectl config set-cluster default
-      --server=https://{{ apiserver_endpoint }}:6443
+      --server=https://{{ apiserver_endpoint }}:{{ apiserver_port | default(6443) }}
       --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true
 

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
 - name: Clean previous runs of k3s-init
-  systemd:
+  ansible.builtin.systemd:
     name: k3s-init
     state: stopped
   failed_when: false
 
 - name: Clean previous runs of k3s-init
-  command: systemctl reset-failed k3s-init
+  ansible.builtin.command: systemctl reset-failed k3s-init
   failed_when: false
   changed_when: false
   args:
     warn: false  # The ansible systemd module does not support reset-failed
 
 - name: Init cluster inside the transient k3s-init service
-  command:
+  ansible.builtin.command:
     cmd: "systemd-run -p RestartSec=2 \
                       -p Restart=on-failure \
                       --unit=k3s-init \
@@ -25,7 +25,7 @@
 - name: Verification
   block:
     - name: Verify that all nodes actually joined (check k3s-init.service if this fails)
-      command:
+      ansible.builtin.command:
         cmd: k3s kubectl get nodes -l "node-role.kubernetes.io/master=true" -o=jsonpath="{.items[*].metadata.name}"
       register: nodes
       until: nodes.rc == 0 and (nodes.stdout.split() | length) == (groups['master'] | length)
@@ -34,14 +34,14 @@
       changed_when: false
   always:
     - name: Kill the temporary service used for initialization
-      systemd:
+      ansible.builtin.systemd:
         name: k3s-init
         state: stopped
       failed_when: false
 
 - name: Copy K3s service file
   register: k3s_service
-  template:
+  ansible.builtin.template:
     src: "k3s.service.j2"
     dest: "{{ systemd_dir }}/k3s.service"
     owner: root
@@ -49,49 +49,49 @@
     mode: 0755
 
 - name: Enable and check K3s service
-  systemd:
+  ansible.builtin.systemd:
     name: k3s
     daemon_reload: yes
     state: restarted
     enabled: yes
 
 - name: Wait for node-token
-  wait_for:
+  ansible.builtin.wait_for:
     path: /var/lib/rancher/k3s/server/node-token
 
 - name: Register node-token file access mode
-  stat:
+  ansible.builtin.stat:
     path: /var/lib/rancher/k3s/server
   register: p
 
 - name: Change file access node-token
-  file:
+  ansible.builtin.file:
     path: /var/lib/rancher/k3s/server
     mode: "g+rx,o+rx"
 
 - name: Read node-token from master
-  slurp:
+  ansible.builtin.slurp:
     src: /var/lib/rancher/k3s/server/node-token
   register: node_token
 
 - name: Store Master node-token
-  set_fact:
+  ansible.builtin.set_fact:
     token: "{{ node_token.content | b64decode | regex_replace('\n', '') }}"
 
 - name: Restore node-token file access
-  file:
+  ansible.builtin.file:
     path: /var/lib/rancher/k3s/server
     mode: "{{ p.stat.mode }}"
 
 - name: Create directory .kube
-  file:
+  ansible.builtin.file:
     path: ~{{ ansible_user }}/.kube
     state: directory
     owner: "{{ ansible_user }}"
     mode: "u=rwx,g=rx,o="
 
 - name: Copy config file to user home directory
-  copy:
+  ansible.builtin.copy:
     src: /etc/rancher/k3s/k3s.yaml
     dest: ~{{ ansible_user }}/.kube/config
     remote_src: yes
@@ -99,20 +99,20 @@
     mode: "u=rw,g=,o="
 
 - name: Configure kubectl cluster to https://{{ apiserver_endpoint }}:{{ apiserver_port | default(6443) }}
-  command: >-
+  ansible.builtin.command: >-
     k3s kubectl config set-cluster default
       --server=https://{{ apiserver_endpoint }}:{{ apiserver_port | default(6443) }}
       --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true
 
 - name: Create kubectl symlink
-  file:
+  ansible.builtin.file:
     src: /usr/local/bin/k3s
     dest: /usr/local/bin/kubectl
     state: link
 
 - name: Create crictl symlink
-  file:
+  ansible.builtin.file:
     src: /usr/local/bin/k3s
     dest: /usr/local/bin/crictl
     state: link

--- a/roles/k3s/node/tasks/main.yml
+++ b/roles/k3s/node/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Copy K3s service file
-  template:
+  ansible.builtin.template:
     src: "k3s.service.j2"
     dest: "{{ systemd_dir }}/k3s-node.service"
     owner: root
@@ -9,7 +9,7 @@
     mode: 0755
 
 - name: Enable and check K3s service
-  systemd:
+  ansible.builtin.systemd:
     name: k3s-node
     daemon_reload: yes
     state: restarted

--- a/roles/k3s/node/templates/k3s.service.j2
+++ b/roles/k3s/node/templates/k3s.service.j2
@@ -7,7 +7,7 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint }}:6443 --token {{ hostvars[groups['master'][0]]['token'] | default(k3s_token) }} {{ extra_agent_args | default("") }}
+ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint }}:{{ apiserver_port | default(6443) }} --token {{ hostvars[groups['master'][0]]['token'] | default(k3s_token) }} {{ extra_agent_args | default("") }}
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -19,7 +19,7 @@
     reload: yes
 
 - name: Add br_netfilter to /etc/modules-load.d/
-  copy:
+  ansible.builtin.copy:
     content: "br_netfilter"
     dest: /etc/modules-load.d/br_netfilter.conf
     mode: "u=rw,g=,o="
@@ -43,7 +43,7 @@
     - net.bridge.bridge-nf-call-ip6tables
 
 - name: Add /usr/local/bin to sudo secure_path
-  lineinfile:
+  ansible.builtin.lineinfile:
     line: 'Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin'
     regexp: "Defaults(\\s)*secure_path(\\s)*="
     state: present

--- a/roles/raspberrypi/handlers/main.yml
+++ b/roles/raspberrypi/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: reboot
-  reboot:
+  ansible.builtin.reboot:

--- a/roles/raspberrypi/tasks/main.yml
+++ b/roles/raspberrypi/tasks/main.yml
@@ -1,24 +1,24 @@
 ---
 - name: Test for raspberry pi /proc/cpuinfo
-  command: grep -E "Raspberry Pi|BCM2708|BCM2709|BCM2835|BCM2836" /proc/cpuinfo
+  ansible.builtin.command: grep -E "Raspberry Pi|BCM2708|BCM2709|BCM2835|BCM2836" /proc/cpuinfo
   register: grep_cpuinfo_raspberrypi
   failed_when: false
   changed_when: false
 
 - name: Test for raspberry pi /proc/device-tree/model
-  command: grep -E "Raspberry Pi" /proc/device-tree/model
+  ansible.builtin.command: grep -E "Raspberry Pi" /proc/device-tree/model
   register: grep_device_tree_model_raspberrypi
   failed_when: false
   changed_when: false
 
 - name: Set raspberry_pi fact to true
-  set_fact:
+  ansible.builtin.set_fact:
     raspberry_pi: true
   when:
     grep_cpuinfo_raspberrypi.rc == 0 or grep_device_tree_model_raspberrypi.rc == 0
 
 - name: Set detected_distribution to Raspbian
-  set_fact:
+  ansible.builtin.set_fact:
     detected_distribution: Raspbian
   when: >
     raspberry_pi|default(false) and
@@ -26,7 +26,7 @@
       ansible_facts.lsb.description|default("") is match("[Rr]aspbian.*") )
 
 - name: Set detected_distribution to Raspbian (ARM64 on Debian Buster)
-  set_fact:
+  ansible.builtin.set_fact:
     detected_distribution: Raspbian
   when:
     - ansible_facts.architecture is search("aarch64")
@@ -34,7 +34,7 @@
     - ansible_facts.lsb.description|default("") is match("Debian.*buster")
 
 - name: Set detected_distribution_major_version
-  set_fact:
+  ansible.builtin.set_fact:
     detected_distribution_major_version: "{{ ansible_facts.lsb.major_release }}"
   when:
     - detected_distribution | default("") == "Raspbian"

--- a/roles/raspberrypi/tasks/prereq/CentOS.yml
+++ b/roles/raspberrypi/tasks/prereq/CentOS.yml
@@ -1,6 +1,6 @@
 ---
 - name: Enable cgroup via boot commandline if not already enabled for Centos
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /boot/cmdline.txt
     backrefs: yes
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'

--- a/roles/raspberrypi/tasks/prereq/Raspbian.yml
+++ b/roles/raspberrypi/tasks/prereq/Raspbian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Activating cgroup support
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /boot/cmdline.txt
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
@@ -8,7 +8,7 @@
   notify: reboot
 
 - name: Flush iptables before changing to iptables-legacy
-  iptables:
+  ansible.builtin.iptables:
     flush: true
   changed_when: false   # iptables flush always returns changed
 

--- a/roles/raspberrypi/tasks/prereq/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/prereq/Ubuntu.yml
@@ -1,6 +1,6 @@
 ---
 - name: Enable cgroup via boot commandline if not already enabled for Ubuntu on a Raspberry Pi
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /boot/firmware/cmdline.txt
     backrefs: yes
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Disable services
-  systemd:
+  ansible.builtin.systemd:
     name: "{{ item }}"
     state: stopped
     enabled: no
@@ -12,7 +12,7 @@
 
 - name: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim-runc"
   register: pkill_containerd_shim_runc
-  command: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim-runc"
+  ansible.builtin.command: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim-runc"
   changed_when: "pkill_containerd_shim_runc.rc == 0"
   failed_when: false
 
@@ -27,7 +27,7 @@
     loop_var: mounted_fs
 
 - name: Remove service files, binaries and data
-  file:
+  ansible.builtin.file:
     name: "{{ item }}"
     state: absent
   with_items:
@@ -39,5 +39,5 @@
     - /usr/local/bin/k3s
 
 - name: daemon_reload
-  systemd:
+  ansible.builtin.systemd:
     daemon_reload: yes

--- a/roles/reset/tasks/umount_with_children.yml
+++ b/roles/reset/tasks/umount_with_children.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get the list of mounted filesystems
-  shell: set -o pipefail && cat /proc/mounts | awk '{ print $2}' | grep -E "^{{ mounted_fs }}"
+  ansible.builtin.shell: set -o pipefail && cat /proc/mounts | awk '{ print $2}' | grep -E "^{{ mounted_fs }}"
   register: get_mounted_filesystems
   args:
     executable: /bin/bash


### PR DESCRIPTION
Added a new `apiserver_port` variable to allow users to specify an alternate port for the loadbalanced apiserver endpoint. This is required if port 6443 is already in use on the loadbalancer (e.g., if you have multiple clusters behind the same loadbalancer frontend IP.) 6443 is set as a default to maintain compatibility in case `apiserver_port` is not defined.

Note: This only configures the port for the loadbalanced apiserver endpoint; nodes themselves will still listen on 6443.