### PR TITLE
Chore: update requirements and use FQDNs

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,3 +1,7 @@
 ---
 collections:
+  - name: ansible.posix
+    version: 1.3.0
+
   - name: community.general
+    version: 4.8.1

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Download k3s binary x64
-  get_url:
+  ansible.builtin.get_url:
     url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s
     checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-amd64.txt
     dest: /usr/local/bin/k3s
@@ -11,7 +11,7 @@
   when: ansible_facts.architecture == "x86_64"
 
 - name: Download k3s binary arm64
-  get_url:
+  ansible.builtin.get_url:
     url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s-arm64
     checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-arm64.txt
     dest: /usr/local/bin/k3s
@@ -24,7 +24,7 @@
       ansible_facts.architecture is search("aarch64")
 
 - name: Download k3s binary armhf
-  get_url:
+  ansible.builtin.get_url:
     url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s-armhf
     checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-arm.txt
     dest: /usr/local/bin/k3s

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
-
 - name: Copy K3s service file
   register: k3s_service
-  template:
+  ansible.builtin.template:
     src: "k3s.service.j2"
     dest: "{{ systemd_dir }}/k3s.service"
     owner: root
@@ -10,49 +9,49 @@
     mode: 0644
 
 - name: Enable and check K3s service
-  systemd:
+  ansible.builtin.systemd:
     name: k3s
     daemon_reload: yes
     state: restarted
     enabled: yes
 
 - name: Wait for node-token
-  wait_for:
+  ansible.builtin.wait_for:
     path: "{{ k3s_server_location }}/server/node-token"
 
 - name: Register node-token file access mode
-  stat:
+  ansible.builtin.stat:
     path: "{{ k3s_server_location }}/server/node-token"
   register: p
 
 - name: Change file access node-token
-  file:
+  ansible.builtin.file:
     path: "{{ k3s_server_location }}/server/node-token"
     mode: "g+rx,o+rx"
 
 - name: Read node-token from master
-  slurp:
+  ansible.builtin.slurp:
     path: "{{ k3s_server_location }}/server/node-token"
   register: node_token
 
 - name: Store Master node-token
-  set_fact:
+  ansible.builtin.set_fact:
     token: "{{ node_token.content | b64decode | regex_replace('\n', '') }}"
 
 - name: Restore node-token file access
-  file:
+  ansible.builtin.file:
     path: "{{ k3s_server_location }}/server/node-token"
     mode: "{{ p.stat.mode }}"
 
 - name: Create directory .kube
-  file:
+  ansible.builtin.file:
     path: ~{{ ansible_user }}/.kube
     state: directory
     owner: "{{ ansible_user }}"
     mode: "u=rwx,g=rx,o="
 
 - name: Copy config file to user home directory
-  copy:
+  ansible.builtin.copy:
     src: /etc/rancher/k3s/k3s.yaml
     dest: ~{{ ansible_user }}/.kube/config
     remote_src: yes
@@ -60,20 +59,20 @@
     mode: "u=rw,g=,o="
 
 - name: Replace https://localhost:6443 by https://master-ip:6443
-  command: >-
+  ansible.builtin.command: >-
     k3s kubectl config set-cluster default
       --server=https://{{ master_ip }}:6443
       --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true
 
 - name: Create kubectl symlink
-  file:
+  ansible.builtin.file:
     src: /usr/local/bin/k3s
     dest: /usr/local/bin/kubectl
     state: link
 
 - name: Create crictl symlink
-  file:
+  ansible.builtin.file:
     src: /usr/local/bin/k3s
     dest: /usr/local/bin/crictl
     state: link

--- a/roles/k3s/node/tasks/main.yml
+++ b/roles/k3s/node/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Copy K3s service file
-  template:
+  ansible.builtin.template:
     src: "k3s.service.j2"
     dest: "{{ systemd_dir }}/k3s-node.service"
     owner: root
@@ -9,7 +9,7 @@
     mode: 0755
 
 - name: Enable and check K3s service
-  systemd:
+  ansible.builtin.systemd:
     name: k3s-node
     daemon_reload: yes
     state: restarted

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
 - name: Set SELinux to disabled state
-  selinux:
+  ansible.posix.selinux:
     state: disabled
   when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
 
 - name: Enable IPv4 forwarding
-  sysctl:
+  ansible.posix.sysctl:
     name: net.ipv4.ip_forward
     value: "1"
     state: present
     reload: yes
 
 - name: Enable IPv6 forwarding
-  sysctl:
+  ansible.posix.sysctl:
     name: net.ipv6.conf.all.forwarding
     value: "1"
     state: present
@@ -20,20 +20,20 @@
   when: ansible_all_ipv6_addresses
 
 - name: Add br_netfilter to /etc/modules-load.d/
-  copy:
+  ansible.builtin.copy:
     content: "br_netfilter"
     dest: /etc/modules-load.d/br_netfilter.conf
     mode: "u=rw,g=,o="
   when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
 
 - name: Load br_netfilter
-  modprobe:
+  community.general.modprobe:
     name: br_netfilter
     state: present
   when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
 
 - name: Set bridge-nf-call-iptables (just to be sure)
-  sysctl:
+  ansible.posix.sysctl:
     name: "{{ item }}"
     value: "1"
     state: present
@@ -44,7 +44,7 @@
     - net.bridge.bridge-nf-call-ip6tables
 
 - name: Add /usr/local/bin to sudo secure_path
-  lineinfile:
+  ansible.builtin.lineinfile:
     line: 'Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin'
     regexp: "Defaults(\\s)*secure_path(\\s)*="
     state: present

--- a/roles/raspberrypi/handlers/main.yml
+++ b/roles/raspberrypi/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: reboot
-  reboot:
+  ansible.builtin.reboot:

--- a/roles/raspberrypi/tasks/main.yml
+++ b/roles/raspberrypi/tasks/main.yml
@@ -1,24 +1,24 @@
 ---
 - name: Test for raspberry pi /proc/cpuinfo
-  command: grep -E "Raspberry Pi|BCM2708|BCM2709|BCM2835|BCM2836" /proc/cpuinfo
+  ansible.builtin.command: grep -E "Raspberry Pi|BCM2708|BCM2709|BCM2835|BCM2836" /proc/cpuinfo
   register: grep_cpuinfo_raspberrypi
   failed_when: false
   changed_when: false
 
 - name: Test for raspberry pi /proc/device-tree/model
-  command: grep -E "Raspberry Pi" /proc/device-tree/model
+  ansible.builtin.command: grep -E "Raspberry Pi" /proc/device-tree/model
   register: grep_device_tree_model_raspberrypi
   failed_when: false
   changed_when: false
 
 - name: Set raspberry_pi fact to true
-  set_fact:
+  ansible.builtin.set_fact:
     raspberry_pi: true
   when:
     grep_cpuinfo_raspberrypi.rc == 0 or grep_device_tree_model_raspberrypi.rc == 0
 
 - name: Set detected_distribution to Raspbian
-  set_fact:
+  ansible.builtin.set_fact:
     detected_distribution: Raspbian
   when: >
     raspberry_pi|default(false) and
@@ -26,7 +26,7 @@
       ansible_facts.lsb.description|default("") is match("[Rr]aspbian.*") )
 
 - name: Set detected_distribution to Raspbian (ARM64 on Debian Buster)
-  set_fact:
+  ansible.builtin.set_fact:
     detected_distribution: Raspbian
   when:
     - ansible_facts.architecture is search("aarch64")
@@ -34,13 +34,13 @@
     - ansible_facts.lsb.description|default("") is match("Debian.*buster")
 
 - name: Set detected_distribution_major_version
-  set_fact:
+  ansible.builtin.set_fact:
     detected_distribution_major_version: "{{ ansible_facts.lsb.major_release }}"
   when:
     - detected_distribution | default("") == "Raspbian"
 
 - name: execute OS related tasks on the Raspberry Pi
-  include_tasks: "{{ item }}"
+  ansible.builtin.include_tasks: "{{ item }}"
   with_first_found:
     - "prereq/{{ detected_distribution }}-{{ detected_distribution_major_version }}.yml"
     - "prereq/{{ detected_distribution }}.yml"

--- a/roles/raspberrypi/tasks/prereq/CentOS.yml
+++ b/roles/raspberrypi/tasks/prereq/CentOS.yml
@@ -1,6 +1,6 @@
 ---
 - name: Enable cgroup via boot commandline if not already enabled for Centos
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /boot/cmdline.txt
     backrefs: yes
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'

--- a/roles/raspberrypi/tasks/prereq/Raspbian.yml
+++ b/roles/raspberrypi/tasks/prereq/Raspbian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Activating cgroup support
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /boot/cmdline.txt
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
@@ -8,18 +8,18 @@
   notify: reboot
 
 - name: Flush iptables before changing to iptables-legacy
-  iptables:
+  ansible.builtin.iptables:
     flush: true
   changed_when: false   # iptables flush always returns changed
 
 - name: Changing to iptables-legacy
-  alternatives:
+  community.general.alternatives:
     path: /usr/sbin/iptables-legacy
     name: iptables
   register: ip4_legacy
 
 - name: Changing to ip6tables-legacy
-  alternatives:
+  community.general.alternatives:
     path: /usr/sbin/ip6tables-legacy
     name: ip6tables
   register: ip6_legacy

--- a/roles/raspberrypi/tasks/prereq/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/prereq/Ubuntu.yml
@@ -1,6 +1,6 @@
 ---
 - name: Enable cgroup via boot commandline if not already enabled for Ubuntu on a Raspberry Pi
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /boot/firmware/cmdline.txt
     backrefs: yes
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Disable services
-  systemd:
+  ansible.builtin.systemd:
     name: "{{ item }}"
     state: stopped
     enabled: no
@@ -11,7 +11,7 @@
 
 - name: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim-runc"
   register: pkill_containerd_shim_runc
-  command: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim-runc"
+  ansible.builtin.command: pkill -9 -f "k3s/data/[^/]+/bin/containerd-shim-runc"
   changed_when: "pkill_containerd_shim_runc.rc == 0"
   failed_when: false
 
@@ -26,7 +26,7 @@
     loop_var: mounted_fs
 
 - name: Remove service files, binaries and data
-  file:
+  ansible.builtin.file:
     name: "{{ item }}"
     state: absent
   with_items:
@@ -38,5 +38,5 @@
     - /var/lib/rancher/k3s
 
 - name: daemon_reload
-  systemd:
+  ansible.builtin.systemd:
     daemon_reload: yes

--- a/roles/reset/tasks/umount_with_children.yml
+++ b/roles/reset/tasks/umount_with_children.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get the list of mounted filesystems
-  shell: set -o pipefail && cat /proc/mounts | awk '{ print $2}' | grep -E "^{{ mounted_fs }}"
+  ansible.builtin.shell: set -o pipefail && cat /proc/mounts | awk '{ print $2}' | grep -E "^{{ mounted_fs }}"
   register: get_mounted_filesystems
   args:
     executable: /bin/bash
@@ -9,7 +9,7 @@
   check_mode: false
 
 - name: Umount filesystem
-  mount:
+  ansible.posix.mount:
     path: "{{ item }}"
     state: unmounted
   with_items:


### PR DESCRIPTION
* add `ansible.posix` collection used by `selinux`, `sysctl`, and `mount` modules.
* specify version for `community.general` collection
* update task invocations to use FQDNs instead of using short names for compatibility with ansible-core