### PR TITLE
According to https://github.com/k3s-io/k3s/issues/2435

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -25,6 +25,12 @@
   loop_control:
     loop_var: mounted_fs
 
+- name: Remove useless netns
+  shell:
+    "for ns in $( cd /run/netns; ls -1 cni*); do sudo ip netns del $ns; done"
+  register: shellcmd
+  tags: removenetns
+
 - name: Remove service files, binaries and data
   file:
     name: "{{ item }}"


### PR DESCRIPTION
playbook should to remove useless netns while reset.