### PR TITLE
Fixes related to K3s Issue #4234

### DIFF
--- a/roles/raspberrypi/tasks/prereq/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/prereq/Ubuntu.yml
@@ -6,3 +6,10 @@
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
   notify: reboot
+- name: Install Ubuntu Raspi Extra Packages
+  apt:
+    name: 
+    - linux-modules-extra-raspi #Fixes issues in newer Ubuntu where VXLan isn't setup right. See: https://github.com/k3s-io/k3s/issues/4234
+    update_cache: yes
+    state: present
+  when: "ansible_distribution_version is version('20.10', '>=')"


### PR DESCRIPTION
There is an issue with Ubuntu+Raspberry Pis starting in 20.10 that results in issues with Flannel correctly starting up. This patch address this issue and helps to ensure the needed extra packages are installed. 

See https://github.com/k3s-io/k3s/issues/4234 for more details on the issue.