### PR TITLE
k3s download: increase `get_url` timeout 10→60s

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -4,6 +4,7 @@
   get_url:
     url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s
     checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-amd64.txt
+    timeout: 120
     dest: /usr/local/bin/k3s
     owner: root
     group: root
@@ -14,6 +15,7 @@
   get_url:
     url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s-arm64
     checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-arm64.txt
+    timeout: 120
     dest: /usr/local/bin/k3s
     owner: root
     group: root
@@ -27,6 +29,7 @@
   get_url:
     url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s-armhf
     checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-arm.txt
+    timeout: 120
     dest: /usr/local/bin/k3s
     owner: root
     group: root


### PR DESCRIPTION
Hi,

The default `get_url` module timeout is 10s. As the k3s binary is around 60MB, it can take some time to download on slow connections or when many downloads are concurrent (multi-node install).
Increase the timeout a bit from 10s to 60s.

Cheers,
Frank