### PR TITLE
Add support for Rocky, bump default install version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,14 +19,14 @@ def provision(vm, role, node_num)
 
   vm.provision "ansible", run: 'once' do |ansible|
     ansible.compatibility_mode = "2.0"
-    ansible.playbook = "playbook/debug.yml"
+    ansible.playbook = "playbook/site.yml"
     ansible.groups = {
       "server" => NODE_ROLES.grep(/^server/),
       "agent" => NODE_ROLES.grep(/^agent/),
       "k3s_cluster:children" => ["server", "agent"],
     }
     ansible.extra_vars = {
-      k3s_version: "v1.26.5+k3s1",
+      k3s_version: "v1.26.9+k3s1",
       api_endpoint: "#{NETWORK_PREFIX}.100",
       token: "myvagrant",
       # Required to use the private network configured above

--- a/inventory-sample.yml
+++ b/inventory-sample.yml
@@ -13,7 +13,7 @@ k3s_cluster:
   vars:
     ansible_port: 22
     ansible_user: debian
-    k3s_version: v1.25.5+k3s2
+    k3s_version: v1.26.9+k3s1
     token: "mytoken"  # Use ansible vault if you want to keep it secret
     api_endpoint: "{{ hostvars[groups['server'][0]]['ansible_host'] | default(groups['server'][0]) }}"
     extra_server_args: ""

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Set SELinux to disabled state
   ansible.posix.selinux:
     state: disabled
-  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux','RedHat']
+  when: ansible_os_family == 'RedHat'
 
 - name: Install Dependent Ubuntu Packages
   when: ansible_distribution in ['Ubuntu']
@@ -30,13 +30,13 @@
     content: "br_netfilter"
     dest: /etc/modules-load.d/br_netfilter.conf
     mode: "u=rw,g=,o="
-  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux', 'RedHat', 'Archlinux']
+  when: (ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux')
 
 - name: Load br_netfilter
   community.general.modprobe:
     name: br_netfilter
     state: present
-  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux', 'RedHat', 'Archlinux']
+  when: (ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux')
 
 - name: Set bridge-nf-call-iptables (just to be sure)
   ansible.posix.sysctl:
@@ -44,7 +44,7 @@
     value: "1"
     state: present
     reload: true
-  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux', 'RedHat', 'Archlinux']
+  when: (ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux')
   loop:
     - net.bridge.bridge-nf-call-iptables
     - net.bridge.bridge-nf-call-ip6tables
@@ -57,7 +57,7 @@
     insertafter: EOF
     path: /etc/sudoers
     validate: 'visudo -cf %s'
-  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux','RedHat']
+  when: ansible_os_family == 'RedHat'
 
 - name: Setup alternative K3s directory
   when:


### PR DESCRIPTION
#### Changes ####
- Changes checks for Redhat based Distros to checking os_family. This includes Rocky 8/9.
- Bumped Default K3s version

Also validated that SELinux support is working as expected. Now that we use the install script, the correct selinux package is automatically installed. 
#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/183