### PR TITLE
Allow SELinuix on RHEL family

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Set SELinux to disabled state
-  ansible.posix.selinux:
-    state: disabled
-  when: ansible_os_family == 'RedHat'
-
 - name: Install Dependent Ubuntu Packages
   when: ansible_distribution in ['Ubuntu']
   ansible.builtin.apt:


### PR DESCRIPTION
#### Changes ####
- Stop disabling SELinux, we now properly install the correct RPM for each distro

## Testing
HA setup of Rocky 8 Nodes
`extra_server_args: "--selinux"`

See selinux properly applied on all nodes:
```
[root@server-1 vagrant]# semanage fcontext -l | grep k3s
/etc/systemd/system/k3s.*                          regular file       system_u:object_r:container_unit_file_t:s0 
/usr/lib/systemd/system/k3s.*                      regular file       system_u:object_r:container_unit_file_t:s0 
/usr/local/lib/systemd/system/k3s.*                regular file       system_u:object_r:container_unit_file_t:s0 
/usr/local/s?bin/k3s                               regular file       system_u:object_r:container_runtime_exec_t:s0 
/usr/s?bin/k3s                                     regular file       system_u:object_r:container_runtime_exec_t:s0 
/var/lib/rancher/k3s(/.*)?                         all files          system_u:object_r:container_var_lib_t:s0 
/var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)? all files          system_u:object_r:container_ro_file_t:s0 
/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots directory          system_u:object_r:container_file_t:s0 
/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]* directory          system_u:object_r:container_file_t:s0 
/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.* all files          <<None>>
/var/lib/rancher/k3s/data(/.*)?                    all files          system_u:object_r:k3s_data_t:s0 
/var/lib/rancher/k3s/data/.lock                    regular file       system_u:object_r:k3s_lock_t:s0 
/var/lib/rancher/k3s/data/[^/]*/bin(/.*)?          all files          system_u:object_r:k3s_root_t:s0 
/var/lib/rancher/k3s/data/[^/]*/bin/[.]links       regular file       system_u:object_r:k3s_data_t:s0 
/var/lib/rancher/k3s/data/[^/]*/bin/[.]sha256sums  regular file       system_u:object_r:k3s_data_t:s0 
/var/lib/rancher/k3s/data/[^/]*/bin/cni            regular file       system_u:object_r:container_runtime_exec_t:s0 
/var/lib/rancher/k3s/data/[^/]*/bin/containerd     regular file       system_u:object_r:container_runtime_exec_t:s0 
/var/lib/rancher/k3s/data/[^/]*/bin/containerd-shim regular file       system_u:object_r:container_runtime_exec_t:s0 
/var/lib/rancher/k3s/data/[^/]*/bin/containerd-shim-runc-v[12] regular file       system_u:object_r:container_runtime_exec_t:s0 
/var/lib/rancher/k3s/data/[^/]*/bin/runc           regular file       system_u:object_r:container_runtime_exec_t:s0 
/var/lib/rancher/k3s/data/[^/]*/etc(/.*)?          all files          system_u:object_r:container_config_t:s0 
/var/lib/rancher/k3s/storage(/.*)?                 all files          system_u:object_r:container_file_t:s0 
/var/run/k3s(/.*)?                                 all files          system_u:object_r:container_var_run_t:s0 
/var/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)? all files          system_u:object_r:container_runtime_tmpfs_t:s0 
[root@server-1 vagrant]# kubectl get nodes
NAME       STATUS   ROLES                       AGE   VERSION
agent-0    Ready    <none>                      63s   v1.26.9+k3s1
server-0   Ready    control-plane,etcd,master   68s   v1.26.9+k3s1
server-1   Ready    control-plane,etcd,master   35s   v1.26.9+k3s1
server-2   Ready    control-plane,etcd,master   50s   v1.26.9+k3s1
```

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/240