### PR TITLE
Minimal Firewall Exceptions

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: Populate service facts
   ansible.builtin.service_facts:
 
-- name: Handle UFW access
+- name: Allow UFW Exceptions
   when:
     - ansible_facts.services['ufw'] is defined
     - ansible_facts.services['ufw'].state == 'running'
@@ -39,12 +39,21 @@
       changed_when: false
       register: ufw_status
 
-    - name: If ufw enabled, open neccesary ports
+    - name: If ufw enabled, open api port
       when:
         - ufw_status['stdout'] == "Status':' active"
       community.general.ufw:
         rule: allow
         port: "{{ api_port }}"
+        proto: tcp
+
+    - name: If ufw enabled, open etcd ports
+      when:
+        - ufw_status['stdout'] == "Status':' active"
+        - groups['server'] | length > 1
+      community.general.ufw:
+        rule: allow
+        port: "2379:2381"
         proto: tcp
 
     - name: If ufw enabled, allow default CIDRs
@@ -57,6 +66,38 @@
         - 10.42.0.0/16  # Pods
         - 10.43.0.0/16  # Services
 
+- name: Allow Firewalld Exceptions
+  when:
+    - ansible_facts.services['firewalld.service'] is defined
+    - ansible_facts.services['firewalld.service'].state == 'running'
+  block:
+    - name: If firewalld enabled, open api port
+      ansible.posix.firewalld:
+        port: "{{ api_port }}/tcp"
+        zone: trusted
+        state: enabled
+        permanent: true
+        immediate: true
+
+    - name: If firewalld enabled, open etcd ports
+      when: groups['server'] | length > 1
+      ansible.posix.firewalld:
+        port: "2379-2381/tcp"
+        zone: trusted
+        state: enabled
+        permanent: true
+        immediate: true
+
+    - name: If firewalld enabled, allow default CIDRs
+      ansible.posix.firewalld:
+        source: "{{ item }}"
+        zone: trusted
+        state: enabled
+        permanent: true
+        immediate: true
+      loop:
+        - 10.42.0.0/16  # Pods
+        - 10.43.0.0/16  # Services
 
 - name: Add br_netfilter to /etc/modules-load.d/
   ansible.builtin.copy:

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -25,6 +25,39 @@
     reload: true
   when: ansible_all_ipv6_addresses
 
+- name: Populate service facts
+  ansible.builtin.service_facts:
+
+- name: Handle UFW access
+  when:
+    - ansible_facts.services['ufw'] is defined
+    - ansible_facts.services['ufw'].state == 'running'
+  block:
+    - name: Get ufw status
+      ansible.builtin.command:
+        cmd: ufw status
+      changed_when: false
+      register: ufw_status
+
+    - name: If ufw enabled, open neccesary ports
+      when:
+        - ufw_status['stdout'] == "Status':' active"
+      community.general.ufw:
+        rule: allow
+        port: "{{ api_port }}"
+        proto: tcp
+
+    - name: If ufw enabled, allow default CIDRs
+      when:
+        - ufw_status['stdout'] == "Status':' active"
+      community.general.ufw:
+        rule: allow
+        src: '{{ item }}'
+      loop:
+        - 10.42.0.0/16  # Pods
+        - 10.43.0.0/16  # Services
+
+
 - name: Add br_netfilter to /etc/modules-load.d/
   ansible.builtin.copy:
     content: "br_netfilter"


### PR DESCRIPTION
#### Changes ####
- While it is recommended disable firewalls, you can get minimum viable K3s working with a few exceptions. This adds support for ufw and firewalld, the two most common firewalls. 
- Modifying k3s configuration from default such as `--service-cidr` would invalidate these exceptions. This is barebones, its left to the user to modify the firewall if they want more exceptions. See https://docs.k3s.io/installation/requirements#inbound-rules-for-k3s-server-nodes from the most common ports/rules. 

## Testing
Tested on HA configurations of:
- ubuntu 20.04 with UFW enabled
- rocky 8 with firewalld enabled

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/234