### PR TITLE
Ensure OpenSUSE support, install 

### DIFF
--- a/roles/k3s/server/tasks/main.yml
+++ b/roles/k3s/server/tasks/main.yml
@@ -41,7 +41,7 @@
         owner: "{{ ansible_user }}"
         mode: "u=rwx,g=rx,o="
 
-    - name: Pause to allow server startup
+    - name: Pause to allow first server startup
       when: (groups['server'] | length) > 1
       ansible.builtin.pause:
         seconds: 10
@@ -53,6 +53,14 @@
         remote_src: true
         owner: "{{ ansible_user }}"
         mode: "u=rw,g=,o="
+
+    - name: Add K3s autocomplete to user bashrc
+      become: true
+      become_user: "{{ ansible_user }}"
+      ansible.builtin.command:
+        cmd: "k3s completion bash -i"
+      register: out
+      changed_when: out.rc != 0
 
     - name: Change server to API endpoint instead of localhost
       ansible.builtin.command: >-

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -118,6 +118,25 @@
     - net.bridge.bridge-nf-call-iptables
     - net.bridge.bridge-nf-call-ip6tables
 
+- name: Check for Apparmor existence
+  ansible.builtin.stat:
+    path: /sys/module/apparmor/parameters/enabled
+  register: apparmor_enabled
+
+- name: Check if Apparmor is enabled
+  when: apparmor_enabled.stat.exists
+  ansible.builtin.command: cat /sys/module/apparmor/parameters/enabled
+  register: apparmor_status
+  changed_when: false
+
+- name: Install Apparmor Parser
+  when:
+    - apparmor_status.stdout == "Y"
+    - ansible_os_family == 'Suse'
+  ansible.builtin.package:
+    name: apparmor-parser
+    state: present
+
 - name: Add /usr/local/bin to sudo secure_path
   ansible.builtin.lineinfile:
     line: 'Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin'

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -129,12 +129,21 @@
   register: apparmor_status
   changed_when: false
 
-- name: Install Apparmor Parser
+- name: Install Apparmor Parser [Suse]
   when:
     - apparmor_status.stdout == "Y"
     - ansible_os_family == 'Suse'
   ansible.builtin.package:
     name: apparmor-parser
+    state: present
+
+- name: Install Apparmor Parser [Debian]
+  when:
+    - apparmor_status.stdout == "Y"
+    - ansible_distribution == 'Debian'
+    - ansible_facts['distribution_major_version'] == "11"
+  ansible.builtin.package:
+    name: apparmor
     state: present
 
 - name: Add /usr/local/bin to sudo secure_path


### PR DESCRIPTION
#### Changes ####
- Handle lack of apparmor_parser in OpenSUSE Leap. Otherwise, SUSE distros work just fine, no changes required. 
- Handle edge case where some Debian 11 images lacked apparmor_parser as well. 
- Enabled K3s autocomplete for the ansible user (bash shell only)

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/175
https://github.com/k3s-io/k3s-ansible/issues/196