### PR TITLE
Handle older iptables in Debian and Raspberry PI OS

### DIFF
--- a/playbook/reset.yml
+++ b/playbook/reset.yml
@@ -4,9 +4,15 @@
   gather_facts: true
   become: true
   tasks:
-    - name: Run K3s Uninstall script
+    - name: Run K3s Uninstall script [server]
+      when: "'server' in group_names"
       ansible.builtin.command:
         cmd: k3s-uninstall.sh
+        removes: /var/lib/rancher/k3s/*
+    - name: Run K3s Uninstall script [agent]
+      when: "'agent' in group_names"
+      ansible.builtin.command:
+        cmd: k3s-agent-uninstall.sh
         removes: /var/lib/rancher/k3s/*
     - name: Remove user kubeconfig
       ansible.builtin.file:

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -8,10 +8,21 @@
     group: root
     mode: 0755
 
-- name: Download k3s binary
+- name: Download k3s binary [server]
+  when: "'server' in group_names"
   ansible.builtin.command:
     cmd: /usr/local/bin/k3s-install.sh
   environment:
     INSTALL_K3S_SKIP_START: "true"
     INSTALL_K3S_VERSION: "{{ k3s_version }}"
+  changed_when: true
+
+- name: Download k3s binary [agent]
+  when: "'agent' in group_names"
+  ansible.builtin.command:
+    cmd: /usr/local/bin/k3s-install.sh
+  environment:
+    INSTALL_K3S_SKIP_START: "true"
+    INSTALL_K3S_VERSION: "{{ k3s_version }}"
+    INSTALL_K3S_EXEC: "agent"
   changed_when: true

--- a/roles/k3s/server/tasks/main.yml
+++ b/roles/k3s/server/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Init first server node
-  when: ansible_hostname == groups['server'][0]
+  # Handle both hostname OR ip address being supplied in inventory
+  when: ansible_hostname == groups['server'][0] or groups['server'][0] in ansible_facts['all_ipv4_addresses']
   block:
     - name: Copy K3s service file [Single]
       when: groups['server'] | length == 1

--- a/roles/raspberrypi/tasks/main.yml
+++ b/roles/raspberrypi/tasks/main.yml
@@ -41,17 +41,9 @@
     - raspberry_pi|default(false)
     - ansible_facts.os_family is match("Archlinux")
 
-- name: Set detected_distribution_major_version
-  ansible.builtin.set_fact:
-    detected_distribution_major_version: "{{ ansible_facts.lsb.major_release }}"
-  when: >
-    ( detected_distribution | default("") == "Raspbian" or
-      detected_distribution | default("") == "Debian" )
-
 - name: Execute OS related tasks on the Raspberry Pi
   ansible.builtin.include_tasks: "{{ item }}"
   with_first_found:
-    - "prereq/{{ detected_distribution }}-{{ detected_distribution_major_version }}.yml"
     - "prereq/{{ detected_distribution }}.yml"
     - "prereq/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
     - "prereq/{{ ansible_distribution }}.yml"

--- a/roles/raspberrypi/tasks/prereq/Debian.yml
+++ b/roles/raspberrypi/tasks/prereq/Debian.yml
@@ -12,23 +12,36 @@
     backrefs: true
   notify: Reboot Pi
 
-- name: Install iptables
-  ansible.builtin.apt:
-    name: iptables
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
 
-- name: Flush iptables before changing to iptables-legacy
-  ansible.builtin.iptables:
-    flush: true
-  changed_when: false   # iptables flush always returns changed
+# If no iptables is found, K3s will use the iptables it ships with.
+# However, if a iptables is found, K3s will use that instead. Iptables
+# versions 1.8.7 and older have problems with K3s, so we force the use of
+# iptables-legacy in that case.
+- name: If old iptables found, change to iptables-legacy
+  when:
+    - ansible_facts.packages['iptables'] is defined
+    - ansible_facts.packages['iptables'][0]['version'] is version('1.8.8', '<')
+  block:
+    - name: Iptables version on node
+      ansible.builtin.debug:
+        msg: "iptables version {{ ansible_facts.packages['iptables'][0]['version'] }} found"
 
-- name: Changing to iptables-legacy
-  community.general.alternatives:
-    path: /usr/sbin/iptables-legacy
-    name: iptables
-  register: ip4_legacy
+    - name: Flush iptables before changing to iptables-legacy
+      ansible.builtin.iptables:
+        flush: true
+      changed_when: false   # iptables flush always returns changed
 
-- name: Changing to ip6tables-legacy
-  community.general.alternatives:
-    path: /usr/sbin/ip6tables-legacy
-    name: ip6tables
-  register: ip6_legacy
+    - name: Changing to iptables-legacy
+      community.general.alternatives:
+        path: /usr/sbin/iptables-legacy
+        name: iptables
+      register: ip4_legacy
+
+    - name: Changing to ip6tables-legacy
+      community.general.alternatives:
+        path: /usr/sbin/ip6tables-legacy
+        name: ip6tables
+      register: ip6_legacy

--- a/roles/raspberrypi/tasks/prereq/Raspbian.yml
+++ b/roles/raspberrypi/tasks/prereq/Raspbian.yml
@@ -7,19 +7,36 @@
     backrefs: true
   notify: Reboot Pi
 
-- name: Flush iptables before changing to iptables-legacy
-  ansible.builtin.iptables:
-    flush: true
-  changed_when: false   # iptables flush always returns changed
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
 
-- name: Changing to iptables-legacy
-  community.general.alternatives:
-    path: /usr/sbin/iptables-legacy
-    name: iptables
-  register: ip4_legacy
+# If no iptables is found, K3s will use the iptables it ships with.
+# However, if a iptables is found, K3s will use that instead. Iptables
+# versions 1.8.7 and older have problems with K3s, so we force the use of
+# iptables-legacy in that case.
+- name: If old iptables found, change to iptables-legacy
+  when:
+    - ansible_facts.packages['iptables'] is defined
+    - ansible_facts.packages['iptables'][0]['version'] is version('1.8.8', '<')
+  block:
+    - name: Iptables version on node
+      ansible.builtin.debug:
+        msg: "iptables version {{ ansible_facts.packages['iptables'][0]['version'] }} found"
 
-- name: Changing to ip6tables-legacy
-  community.general.alternatives:
-    path: /usr/sbin/ip6tables-legacy
-    name: ip6tables
-  register: ip6_legacy
+    - name: Flush iptables before changing to iptables-legacy
+      ansible.builtin.iptables:
+        flush: true
+      changed_when: false   # iptables flush always returns changed
+
+    - name: Changing to iptables-legacy
+      community.general.alternatives:
+        path: /usr/sbin/iptables-legacy
+        name: iptables
+      register: ip4_legacy
+
+    - name: Changing to ip6tables-legacy
+      community.general.alternatives:
+        path: /usr/sbin/ip6tables-legacy
+        name: ip6tables
+      register: ip6_legacy


### PR DESCRIPTION
#### Changes ####
- Only use iptables alternatives if iptables is installed with versions older than 1.8.8 (debian 11 ships with 1.8.7)
- Fixes issue where using IPs as the inventory value would cause the first server node skip startup
- Properly handled the downloading/removal of `k3s-agent.service`. Before we were unnecessarily installing the k3s server service alongside the agent service. 

#### Testing
Tested on a 1 server 1 agent setup of:
server: PI4 with Raspberry Pi OS 12 (no iptables installed) (also weirdly this doesn't report as PI OS, just vanilla debian now??)
agent: PI4 with Raspberry Pi OS 11 (old iptables installed)

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/157