### PR TITLE
Rework iptables old version checks

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -148,6 +148,22 @@
     name: apparmor
     state: present
 
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+# Iptables v1.8.0-1.8.4 have a specific bug with K3s. https://github.com/k3s-io/k3s/issues/3117
+- name: If iptables v1.8.0-1.8.4, warn user  # noqa ignore-errors
+  when:
+    - ansible_facts.packages['iptables'] is defined
+    - ansible_facts.packages['iptables'][0]['version'] is version('1.8.5', '<')
+    - ansible_facts.packages['iptables'][0]['version'] is version('1.7.9', '>')
+  ansible.builtin.fail:
+    msg:
+      - "Warning: Iptables {{ ansible_facts.packages['iptables'][0]['version'] }} found."
+      - "Add '--prefer-bundled-bin' to extra_server_args variable to use the bundled iptables binary."
+  ignore_errors: true
+
 - name: Add /usr/local/bin to sudo secure_path
   ansible.builtin.lineinfile:
     line: 'Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin'

--- a/roles/raspberrypi/tasks/prereq/Debian.yml
+++ b/roles/raspberrypi/tasks/prereq/Debian.yml
@@ -16,14 +16,12 @@
   ansible.builtin.package_facts:
     manager: auto
 
-# If no iptables is found, K3s will use the iptables it ships with.
-# However, if a iptables is found, K3s will use that instead. Iptables
-# versions 1.8.7 and older have problems with K3s, so we force the use of
+# IPtables versions 1.6.1 and older have problems with K3s, so we force the use of
 # iptables-legacy in that case.
 - name: If old iptables found, change to iptables-legacy
   when:
     - ansible_facts.packages['iptables'] is defined
-    - ansible_facts.packages['iptables'][0]['version'] is version('1.8.8', '<')
+    - ansible_facts.packages['iptables'][0]['version'] is version('1.6.2', '<')
   block:
     - name: Iptables version on node
       ansible.builtin.debug:

--- a/roles/raspberrypi/tasks/prereq/Raspbian.yml
+++ b/roles/raspberrypi/tasks/prereq/Raspbian.yml
@@ -11,14 +11,12 @@
   ansible.builtin.package_facts:
     manager: auto
 
-# If no iptables is found, K3s will use the iptables it ships with.
-# However, if a iptables is found, K3s will use that instead. Iptables
-# versions 1.8.7 and older have problems with K3s, so we force the use of
+# IPtables versions 1.6.1 and older have problems with K3s, so we force the use of
 # iptables-legacy in that case.
 - name: If old iptables found, change to iptables-legacy
   when:
     - ansible_facts.packages['iptables'] is defined
-    - ansible_facts.packages['iptables'][0]['version'] is version('1.8.8', '<')
+    - ansible_facts.packages['iptables'][0]['version'] is version('1.6.2', '<')
   block:
     - name: Iptables version on node
       ansible.builtin.debug:


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Changes ####
I had the known issues backwards in my head. Now we correctly:
- Swap to iptables legacy only for v1.6.1 and older Iptables versions
- Warn the user that `--prefer-bundled-bin` should be used with iptables v1.8.0-1.8.4 (i.e. Debian10 and CentOS8)
#### Linked Issues ####