### PR TITLE
clone virtuablbox vms

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,6 +50,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |v|
     v.cpus = NODE_CPUS
     v.memory = NODE_MEMORY
+    v.linked_clone = true
   end
   
   NODE_ROLES.each_with_index do |name, i|


### PR DESCRIPTION
#### Changes ####
Use virtualbox clone vm to speedup provision and disk save

#### Linked Issues ####

#### Comparisons to master ####
without clone:
```
$ time vagrant up server-0 agent-0 agent-1
45.01s user 26.17s system 5% cpu 21:06.77 total
$ du -sh VirtualBox\ VMs/k3s-ansible_*
5.6G	VirtualBox VMs/k3s-ansible_agent-0_1700944617844_4920
5.4G	VirtualBox VMs/k3s-ansible_agent-1_1700944988316_45689
6.2G	VirtualBox VMs/k3s-ansible_server-0_1700944207941_53134
```

with clone:
```
$ vagrant up server-0 agent-0 agent-1
40.17s user 21.25s system 7% cpu 14:25.32 total
$ du -sh VirtualBox\ VMs/k3s-ansible_* VirtualBox\ VMs/generic-*
4.5G	VirtualBox VMs/generic-ubuntu2004-virtualbox-x64_1700945558989_1414
1.3G	VirtualBox VMs/k3s-ansible_agent-0_1700945933583_55185
1.2G	VirtualBox VMs/k3s-ansible_agent-1_1700946237718_63854
1.9G	VirtualBox VMs/k3s-ansible_server-0_1700945630388_82614
```