### PR TITLE
Fixed #260: k3s autocompletion is added to .bashrc only when necessary;

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -75,13 +75,11 @@
         owner: "{{ ansible_user }}"
         mode: "u=rw,g=,o="
 
-    - name: Add K3s autocomplete to user bashrc
-      become: true
-      become_user: "{{ ansible_user }}"
-      ansible.builtin.command:
-        cmd: "k3s completion bash -i"
-      register: out
-      changed_when: out.rc != 0
+    - name: Add K3s autocomplete to ~{{ ansible_user }}/.bashrc
+      ansible.builtin.lineinfile:
+        path: "~{{ ansible_user }}/.bashrc"
+        regexp: '\.\s+<\(k3s completion bash\)'
+        line: ". <(k3s completion bash)  # Added by k3s-ansible"
 
     - name: Change server to API endpoint instead of localhost
       ansible.builtin.command: >-

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -75,7 +75,7 @@
         owner: "{{ ansible_user }}"
         mode: "u=rw,g=,o="
 
-    - name: Add K3s autocomplete to ~{{ ansible_user }}/.bashrc
+    - name: Add K3s autocomplete to user bashrc
       ansible.builtin.lineinfile:
         path: "~{{ ansible_user }}/.bashrc"
         regexp: '\.\s+<\(k3s completion bash\)'


### PR DESCRIPTION
k3s auto-completion is added _~/{{ ansible_user }}/.bashrc_ only when necessary. I replaced the use of **ansible.builtin.command** with **ansible.builtin.lineinfile**. This fixes https://github.com/k3s-io/k3s-ansible/issues/260.