### PR TITLE
do not blindly overwrite kube config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,7 @@ def provision(vm, role, node_num)
   vm.provision "ansible", run: 'once' do |ansible|
     ansible.compatibility_mode = "2.0"
     ansible.playbook = "playbook/site.yml"
+    ansible.verbose = "v"
     ansible.groups = {
       "server" => NODE_ROLES.grep(/^server/),
       "agent" => NODE_ROLES.grep(/^agent/),

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,6 @@ def provision(vm, role, node_num)
   vm.provision "ansible", run: 'once' do |ansible|
     ansible.compatibility_mode = "2.0"
     ansible.playbook = "playbook/site.yml"
-    ansible.verbose = "v"
     ansible.groups = {
       "server" => NODE_ROLES.grep(/^server/),
       "agent" => NODE_ROLES.grep(/^agent/),

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -113,6 +113,12 @@
       when: result.stat.exists
       become: false
 
+    - name: Save a new kube config
+      ansible.builtin.command: mv ~/.kube/config.new ~/.kube/config
+      delegate_to: 127.0.0.1
+      when: not result.stat.exists
+      become: false
+
 - name: Start other server if any and verify status
   when:
     - (groups['server'] | length) > 1

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -112,12 +112,18 @@
       delegate_to: 127.0.0.1
       when: result.stat.exists
       become: false
+      register: mv_result
+      changed_when:
+        - mv_result.rc == 0
 
     - name: Save a new kube config
       ansible.builtin.command: mv ~/.kube/config.new ~/.kube/config
       delegate_to: 127.0.0.1
       when: not result.stat.exists
       become: false
+      register: cp_result
+      changed_when:
+        - cp_result.rc == 0
 
 - name: Start other server if any and verify status
   when:

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -96,22 +96,13 @@
         dest: ~/.kube/config.new
         flat: true
 
-    - name: Check existing kube config
-      ansible.builtin.stat:
-        path: ~/.kube/config
-      register: result
-      delegate_to: 127.0.0.1
-      become: false
-
-    - name: Merge with existing kube config
+    - name: Merge with any existing kube config
       ansible.builtin.shell: |
-        export KUBECONFIG=~/.kube/config:~/.kube/config.new
         TFILE=$(mktemp)
-        kubectl config view --flatten > ${TFILE}
+        KUBECONFIG=~/.kube/config:~/.kube/config.new kubectl config view --flatten > ${TFILE}
         mv ${TFILE} ~/.kube/config
         rm ~/.kube/config.new
       delegate_to: 127.0.0.1
-      when: result.stat.exists
       become: false
       register: mv_result
       changed_when:

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -108,23 +108,6 @@
       changed_when:
         - mv_result.rc == 0
 
-    - name: Save a new kube config
-      ansible.builtin.command: mv ~/.kube/config.new ~/.kube/config
-      delegate_to: 127.0.0.1
-      when: not result.stat.exists
-      become: false
-      register: cp_result
-      changed_when:
-        - cp_result.rc == 0
-
-    - name: Clear access mode bits for kube config
-      ansible.builtin.file:
-        path: ~/.kube/config
-        state: file
-        mode: go=
-      delegate_to: 127.0.0.1
-      become: false
-
 - name: Start other server if any and verify status
   when:
     - (groups['server'] | length) > 1

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -109,6 +109,7 @@
         TFILE=$(mktemp)
         kubectl config view --flatten > ${TFILE}
         mv ${TFILE} ~/.kube/config
+        rm ~/.kube/config.new
       delegate_to: 127.0.0.1
       when: result.stat.exists
       become: false

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -93,8 +93,29 @@
     - name: Copy kubectl config to local machine
       ansible.builtin.fetch:
         src: ~{{ ansible_user }}/.kube/config
-        dest: ~/.kube/config
+        dest: ~/.kube/config.new
         flat: true
+
+    - name: Check existing kube config
+      stat:
+        path: ~/.kube/config
+      register: result
+      delegate_to: 127.0.0.1
+      become: false
+
+    - name: Show results
+      debug:
+        msg: "{{ result.stat.exists }}"
+
+    - name: Merge with existing kube config
+      ansible.builtin.shell: |
+        export KUBECONFIG=~/.kube/config:~/.kube/config.new
+        TFILE=$(mktemp)
+        kubectl config view --flatten > ${TFILE}
+        mv ${TFILE} ~/.kube/config
+      delegate_to: 127.0.0.1
+      when: result.stat.exists
+      become: false
 
 - name: Start other server if any and verify status
   when:

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -97,15 +97,11 @@
         flat: true
 
     - name: Check existing kube config
-      stat:
+      ansible.builtin.stat:
         path: ~/.kube/config
       register: result
       delegate_to: 127.0.0.1
       become: false
-
-    - name: Show results
-      debug:
-        msg: "{{ result.stat.exists }}"
 
     - name: Merge with existing kube config
       ansible.builtin.shell: |

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -125,6 +125,14 @@
       changed_when:
         - cp_result.rc == 0
 
+    - name: Clear access mode bits for kube config
+      ansible.builtin.file:
+        path: ~/.kube/config
+        state: file
+        mode: go=
+      delegate_to: 127.0.0.1
+      become: false
+
 - name: Start other server if any and verify status
   when:
     - (groups['server'] | length) > 1


### PR DESCRIPTION
#### Changes ####

Merge with existing kube config, do not overwrite existing file

#### Linked Issues ####

#259 

One issue still needs to be addressed is when cluster names are identical
