### PR TITLE
make reset work with alt k3s dir and root user

### DIFF
--- a/playbook/reset.yml
+++ b/playbook/reset.yml
@@ -15,9 +15,13 @@
         removes: /var/lib/rancher/k3s/*
     - name: Remove user kubeconfig
       ansible.builtin.file:
-        path: /home/{{ ansible_user }}/.kube/config
+        path: ~{{ ansible_user }}/.kube/config
         state: absent
     - name: Remove k3s install script
       ansible.builtin.file:
         path: /usr/local/bin/k3s-install.sh
         state: absent
+    - name: Remove contents of K3s server location
+      when: k3s_server_location is defined
+      ansible.builtin.shell:
+        cmd: "rm -rf {{ k3s_server_location }}/*"

--- a/playbook/reset.yml
+++ b/playbook/reset.yml
@@ -25,3 +25,4 @@
       when: k3s_server_location is defined
       ansible.builtin.shell:
         cmd: "rm -rf {{ k3s_server_location }}/*"
+      changed_when: true

--- a/playbook/reset.yml
+++ b/playbook/reset.yml
@@ -25,4 +25,4 @@
       when: k3s_server_location is defined
       ansible.builtin.shell:
         cmd: "rm -rf {{ k3s_server_location }}/*"
-      changed_when: true
+        removes: "{{ k3s_server_location }}/*"


### PR DESCRIPTION
#### Changes ####

In the reset playbook, `k3s-uninstall.sh` executes `rm -rf /var/lib/rancher/k3s`. However, if an alternate server location is defined in `k3s_server_location`, the k3s uninstall deletes only the symlink but not the actual source folder. This can lead to complications in reinstalls, for example.

Another suggested change addresses the scenario where reset is executed with `ansible_user` set to `root`.
