### PR TITLE
Role tweaks

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -6,4 +6,4 @@ rules:
     max: 120
     level: warning
   truthy:
-    allowed-values: ['true', 'false', 'yes', 'no']
+    allowed-values: ['true', 'false']

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -21,16 +21,17 @@
   changed_when: true
 
 - name: Copy K3s service file
+  register: k3s_agent_service
   ansible.builtin.template:
     src: "k3s-agent.service.j2"
     dest: "{{ systemd_dir }}/k3s-agent.service"
     owner: root
     group: root
-    mode: 0755
+    mode: "u=rw,g=r,o=r"
 
 - name: Enable and check K3s service
   ansible.builtin.systemd:
     name: k3s-agent
-    daemon_reload: true
-    state: started
+    daemon_reload: "{{ true if k3s_agent_service.changed else false }}"
+    state: "{{ 'restarted' if k3s_agent_service.changed else 'started' }}"
     enabled: true

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -3,7 +3,7 @@
   when: ansible_distribution in ['Ubuntu']
   ansible.builtin.apt:
     name: policycoreutils  # Used by install script to restore SELinux context
-    update_cache: yes
+    update_cache: true
 
 - name: Enable IPv4 forwarding
   ansible.posix.sysctl:

--- a/roles/raspberrypi/handlers/main.yml
+++ b/roles/raspberrypi/handlers/main.yml
@@ -9,3 +9,4 @@
   args:
     chdir: /boot
   notify: Reboot Pi
+  changed_when: true

--- a/roles/raspberrypi/handlers/main.yml
+++ b/roles/raspberrypi/handlers/main.yml
@@ -1,3 +1,11 @@
 ---
 - name: Reboot Pi
   ansible.builtin.reboot:
+    post_reboot_delay: 10
+    reboot_timeout: 60
+
+- name: Regenerate bootloader image
+  ansible.builtin.command: ./mkscr
+  args:
+    chdir: /boot
+  notify: Reboot Pi

--- a/roles/raspberrypi/tasks/prereq/Archlinux.yml
+++ b/roles/raspberrypi/tasks/prereq/Archlinux.yml
@@ -2,6 +2,8 @@
 - name: Enable cgroup via boot commandline if not already enabled
   ansible.builtin.lineinfile:
     path: /boot/boot.txt
+    # yamllint disable-line rule:line-length
     search_string: setenv bootargs console=ttyS1,115200 console=tty0 root=PARTUUID=${uuid} rw rootwait smsc95xx.macaddr="${usbethaddr}"
+    # yamllint disable-line rule:line-length
     line: setenv bootargs console=ttyS1,115200 console=tty0 root=PARTUUID=${uuid} rw rootwait smsc95xx.macaddr="${usbethaddr}" cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory
   notify: Regenerate bootloader image

--- a/roles/raspberrypi/tasks/prereq/Archlinux.yml
+++ b/roles/raspberrypi/tasks/prereq/Archlinux.yml
@@ -4,12 +4,4 @@
     path: /boot/boot.txt
     search_string: setenv bootargs console=ttyS1,115200 console=tty0 root=PARTUUID=${uuid} rw rootwait smsc95xx.macaddr="${usbethaddr}"
     line: setenv bootargs console=ttyS1,115200 console=tty0 root=PARTUUID=${uuid} rw rootwait smsc95xx.macaddr="${usbethaddr}" cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory
-  register: kernel_cmdline_cgroup
-
-- name: Create
-  ansible.builtin.command: ./mkscr
-  args:
-    chdir: /boot
-  notify: Reboot Pi
-  changed_when: false
-  when: kernel_cmdline_cgroup.changed  # noqa: no-handler
+  notify: Regenerate bootloader image

--- a/roles/raspberrypi/tasks/prereq/Archlinux.yml
+++ b/roles/raspberrypi/tasks/prereq/Archlinux.yml
@@ -1,5 +1,5 @@
 ---
-- name: Enable cgroup via boot commandline if not already enabled for Archlinux
+- name: Enable cgroup via boot commandline if not already enabled
   ansible.builtin.lineinfile:
     path: /boot/boot.txt
     search_string: setenv bootargs console=ttyS1,115200 console=tty0 root=PARTUUID=${uuid} rw rootwait smsc95xx.macaddr="${usbethaddr}"

--- a/roles/raspberrypi/tasks/prereq/CentOS.yml
+++ b/roles/raspberrypi/tasks/prereq/CentOS.yml
@@ -2,7 +2,7 @@
 - name: Enable cgroup via boot commandline if not already enabled for Centos
   ansible.builtin.lineinfile:
     path: /boot/cmdline.txt
-    backrefs: yes
+    backrefs: true
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
   notify: Reboot Pi

--- a/roles/raspberrypi/tasks/prereq/CentOS.yml
+++ b/roles/raspberrypi/tasks/prereq/CentOS.yml
@@ -1,5 +1,5 @@
 ---
-- name: Enable cgroup via boot commandline if not already enabled for Centos
+- name: Enable cgroup via boot commandline if not already enabled
   ansible.builtin.lineinfile:
     path: /boot/cmdline.txt
     backrefs: true

--- a/roles/raspberrypi/tasks/prereq/Debian.yml
+++ b/roles/raspberrypi/tasks/prereq/Debian.yml
@@ -7,9 +7,9 @@
 - name: Enable cgroup via boot commandline if not already enabled
   ansible.builtin.lineinfile:
     path: "{{ (boot_firmware_cmdline_txt.stat.exists) | ternary('/boot/firmware/cmdline.txt', '/boot/cmdline.txt') }}"
+    backrefs: true
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
-    backrefs: true
   notify: Reboot Pi
 
 - name: Gather the package facts

--- a/roles/raspberrypi/tasks/prereq/Debian.yml
+++ b/roles/raspberrypi/tasks/prereq/Debian.yml
@@ -4,7 +4,7 @@
     path: /boot/firmware/cmdline.txt
   register: boot_firmware_cmdline_txt
 
-- name: Activating cgroup support
+- name: Enable cgroup via boot commandline if not already enabled
   ansible.builtin.lineinfile:
     path: "{{ (boot_firmware_cmdline_txt.stat.exists) | ternary('/boot/firmware/cmdline.txt', '/boot/cmdline.txt') }}"
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'

--- a/roles/raspberrypi/tasks/prereq/Raspbian.yml
+++ b/roles/raspberrypi/tasks/prereq/Raspbian.yml
@@ -2,9 +2,9 @@
 - name: Enable cgroup via boot commandline if not already enabled
   ansible.builtin.lineinfile:
     path: /boot/cmdline.txt
+    backrefs: true
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
-    backrefs: true
   notify: Reboot Pi
 
 - name: Gather the package facts

--- a/roles/raspberrypi/tasks/prereq/Raspbian.yml
+++ b/roles/raspberrypi/tasks/prereq/Raspbian.yml
@@ -1,5 +1,5 @@
 ---
-- name: Activating cgroup support
+- name: Enable cgroup via boot commandline if not already enabled
   ansible.builtin.lineinfile:
     path: /boot/cmdline.txt
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'

--- a/roles/raspberrypi/tasks/prereq/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/prereq/Ubuntu.yml
@@ -2,7 +2,7 @@
 - name: Enable cgroup via boot commandline if not already enabled for Ubuntu on a Raspberry Pi
   ansible.builtin.lineinfile:
     path: /boot/firmware/cmdline.txt
-    backrefs: yes
+    backrefs: true
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
   notify: Reboot Pi
@@ -11,6 +11,6 @@
     # Fixes issues in newer Ubuntu where VXLan isn't setup right.
     # See: https://github.com/k3s-io/k3s/issues/4234
     name: linux-modules-extra-raspi
-    update_cache: yes
+    update_cache: true
     state: present
   when: "ansible_distribution_version is version('20.10', '>=')"

--- a/roles/raspberrypi/tasks/prereq/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/prereq/Ubuntu.yml
@@ -1,11 +1,12 @@
 ---
-- name: Enable cgroup via boot commandline if not already enabled for Ubuntu on a Raspberry Pi
+- name: Enable cgroup via boot commandline if not already enabled
   ansible.builtin.lineinfile:
     path: /boot/firmware/cmdline.txt
     backrefs: true
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
   notify: Reboot Pi
+
 - name: Install Ubuntu Raspi Extra Packages
   ansible.builtin.apt:
     # Fixes issues in newer Ubuntu where VXLan isn't setup right.


### PR DESCRIPTION
There are minor cosmetic changes in **roles/raspberrypi** to help me bring [my branch](https://github.com/jon-stumpf/k3s-ansible/tree/rebase-upstream) inline with upstream for an eventual merge (originally #267).  I also addressed one task in #264, updating **roles/k3s_agent**.

#### Changes ####
Limited boolean value to true/false
Moved a ArchLinux prereq task to be a handler
Standardized the task name for adding cgroup support across architectures
Moved backrefs: to immediately follow the path:
#### Linked Issues ####
#264, task 7.