### PR TITLE
fix: yaml conditional logic

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -117,7 +117,7 @@
       changed_when: false
 
     - name: Setup kubeconfig k3s-ansible context
-      when: kubeconfig == "~/.kube/config.new" && kubectl_installed.rc == 0
+      when: kubeconfig == "~/.kube/config.new" and kubectl_installed.rc == 0
       ansible.builtin.replace:
         path: "{{ kubeconfig }}"
         regexp: 'name: default'
@@ -126,7 +126,7 @@
       become: false
 
     - name: Merge with any existing kube config
-      when: kubeconfig == "~/.kube/config.new" && kubectl_installed.rc == 0
+      when: kubeconfig == "~/.kube/config.new" and kubectl_installed.rc == 0
       ansible.builtin.shell: |
         TFILE=$(mktemp)
         KUBECONFIG=~/.kube/config.new kubectl rename-context default k3s-ansible


### PR DESCRIPTION
Running the playbook with version 2.16.1 I get a templating error in the conditional checks. I don't think '&&' can be used a logical AND.

```
TASK [k3s_server : Merge with any existing kube config] *********************************************************************************************************************
fatal: [78.47.92.188 -> 127.0.0.1]: FAILED! => {"msg": "The conditional check 'kubeconfig == \"~/.kube/config.new\" && kubectl_installed.rc == 0' failed. The error was: template error while templating string: unexpected char '&' at 41. String: {% if kubeconfig == \"~/.kube/config.new\" && kubectl_installed.rc == 0 %} True {% else %} False {% endif %}. unexpected char '&' at 41\n\nThe error appears to be in '/home/dani/repos/my-cluster/k3s-ansible/roles/k3s_server/tasks/main.yml': line 128, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Merge with any existing kube config\n      ^ here\n"}
```
