### PR TITLE
Use inventory_hostname instead of ansible_hostname

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -34,8 +34,7 @@
         mode: 0644
 
 - name: Init first server node
-  # Handle both hostname OR ip address being supplied in inventory
-  when: ansible_hostname == groups['server'][0] or groups['server'][0] in ansible_facts['all_ipv4_addresses']
+  when: inventory_hostname == groups['server'][0]
   block:
     - name: Copy K3s service file [Single]
       when: groups['server'] | length == 1
@@ -143,7 +142,7 @@
 - name: Start other server if any and verify status
   when:
     - (groups['server'] | length) > 1
-    - ansible_hostname != groups['server'][0]
+    - inventory_hostname != groups['server'][0]
   block:
     - name: Copy K3s service file [HA]
       when: groups['server'] | length > 1


### PR DESCRIPTION
#### Changes ####

Use `inventory_hostname` instead of `ansible_hostname`.

It appears to me that the intention is to check if current host is the first one in the group, then I think it's best to use `inventory_hostname` as it will always work and also doesn't depend on `gather_facts`.

`ansible_hostname` will not work when the host as specified in inventory does not match the hostname discovered on server because of
* FQDN vs. not fully qualified;
* alias in `~/.ssh/config`;
* DNS CNAME;
* or simply it's different on DNS from on server.

#### Linked Issues ####

None.