### PR TITLE
Allow empty `ansible_user`

### DIFF
--- a/inventory-sample.yml
+++ b/inventory-sample.yml
@@ -12,7 +12,7 @@ k3s_cluster:
   # Required Vars
   vars:
     ansible_port: 22
-    ansible_user: debian
+    ansible_user: ""
     k3s_version: v1.26.9+k3s1
     token: "mytoken"  # Use ansible vault if you want to keep it secret
     api_endpoint: "{{ hostvars[groups['server'][0]]['ansible_host'] | default(groups['server'][0]) }}"

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -72,7 +72,7 @@
       ansible.builtin.file:
         path: ~{{ ansible_user }}/.kube
         state: directory
-        owner: "{{ ansible_user }}"
+        owner: "{{ ansible_user | default(omit, true) }}"
         mode: "u=rwx,g=rx,o="
 
     - name: Pause to allow first server startup
@@ -85,7 +85,7 @@
         src: /etc/rancher/k3s/k3s.yaml
         dest: ~{{ ansible_user }}/.kube/config
         remote_src: true
-        owner: "{{ ansible_user }}"
+        owner: "{{ ansible_user | default(omit, true) }}"
         mode: "u=rw,g=,o="
 
     - name: Add K3s autocomplete to user bashrc


### PR DESCRIPTION
#### Changes ####

Allow `ansible_user` to be specified as an empty string.

`ansible_user` specifies the username to use when connecting to hosts, but it should not be required to have a value in my opinion as the same info may also

* be provided in `~/.ssh/config`;
* be omitted if it happens to be the same username on both local and remote;
* be unnecessary if using local connection.

#### Linked Issues ####

None.