### PR TITLE
Completely setup kubectl for ansible_user, with option to disable it

### DIFF
--- a/inventory-sample.yml
+++ b/inventory-sample.yml
@@ -28,6 +28,7 @@ k3s_cluster:
     # List of locally available manifests to apply to the cluster, useful for PVCs or Traefik modifications.
     # extra_manifests: [ '/path/to/manifest1.yaml', '/path/to/manifest2.yaml' ]
     # airgap_dir: /tmp/k3s-airgap-images
+    # user_kubectl: true, by default kubectl is symlinked and configured for use by ansible_user. Set to false to only kubectl via root user.
     # server_config_yaml:  |
       # This is now an inner yaml file. Maintain the indentation.
       # YAML here will be placed as the content of /etc/rancher/k3s/config.yaml

--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -3,3 +3,4 @@ k3s_server_location: "/var/lib/rancher/k3s"
 systemd_dir: "/etc/systemd/system"
 api_port: 6443
 kubeconfig: ~/.kube/config.new
+user_kubectl: true

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -68,25 +68,10 @@
         state: started
         enabled: true
 
-    - name: Create directory .kube
-      ansible.builtin.file:
-        path: ~{{ ansible_user }}/.kube
-        state: directory
-        owner: "{{ ansible_user }}"
-        mode: "u=rwx,g=rx,o="
-
     - name: Pause to allow first server startup
       when: (groups['server'] | length) > 1
       ansible.builtin.pause:
         seconds: 10
-
-    - name: Copy config file to user home directory
-      ansible.builtin.copy:
-        src: /etc/rancher/k3s/k3s.yaml
-        dest: ~{{ ansible_user }}/.kube/config
-        remote_src: true
-        owner: "{{ ansible_user }}"
-        mode: "u=rw,g=,o="
 
     - name: Add K3s autocomplete to user bashrc
       ansible.builtin.lineinfile:
@@ -103,7 +88,7 @@
 
     - name: Copy kubectl config to local machine
       ansible.builtin.fetch:
-        src: ~{{ ansible_user }}/.kube/config
+        src: /etc/rancher/k3s/k3s.yaml
         dest: "{{ kubeconfig }}"
         flat: true
 
@@ -171,11 +156,41 @@
       delay: 10
       changed_when: false
 
-- name: Create symlinks
-  ansible.builtin.file:
-    src: /usr/local/bin/k3s
-    dest: /usr/local/bin/{{ item }}
-    state: link
-  with_items:
-    - kubectl
-    - crictl
+- name: Setup kubectl for user
+  when: user_kubectl
+  block:
+
+    - name: Create kubectl symlink
+      when: lookup('fileglob', '/usr/local/bin/kubectl', errors='warn') | length == 0
+      ansible.builtin.file:
+        src: /usr/local/bin/k3s
+        dest: /usr/local/bin/kubectl
+        state: link
+
+    - name: Create directory .kube
+      ansible.builtin.file:
+        path: ~{{ ansible_user }}/.kube
+        state: directory
+        owner: "{{ ansible_user }}"
+        mode: "u=rwx,g=rx,o="
+
+    - name: Copy config file to user home directory
+      ansible.builtin.copy:
+        src: /etc/rancher/k3s/k3s.yaml
+        dest: ~{{ ansible_user }}/.kube/config
+        remote_src: true
+        owner: "{{ ansible_user }}"
+        mode: "u=rw,g=,o="
+
+    - name: Configure default KUBECONFIG for user
+      ansible.builtin.lineinfile:
+        path: ~{{ ansible_user }}/.bashrc
+        regexp: 'export KUBECONFIG=~/.kube/config'
+        line: 'export KUBECONFIG=~/.kube/config # Added by k3s-ansible'
+        state: present
+
+    - name: Configure kubectl autocomplete
+      ansible.builtin.lineinfile:
+        path: ~{{ ansible_user }}/.bashrc
+        regexp: '\.\s+<\(kubectl completion bash\)'
+        line: ". <(kubectl completion bash)  # Added by k3s-ansible"


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Background ####
Currently even though kubectl is linked to the `ansible_user` and we copy over the kubectl config from `/etc/rancher/k3s/k3s.yaml` running `kubectl get pods` as `ansible_user` would still fail as by default the kubectl provided by k3s uses `/etc/rancher/k3s/k3s.yaml` as the default kubeconfig. This requires the user to additional setup `extra_server_args: --write-kubeconfig-mode=644` for the whole system to work. 

#### Changes ####
- Fully configure the `ansible_user` kubectl for immediate use. Point the default KUBECONFIG to the user accessible ~/.kube/config, and setup kubectl autocompletion
- New default variable `user_kubectl` which allows disabling this kubectl setup steps. Useful if you don't want a local user accessing k3s, only root. 
- Remove link to `k3s crictl` as this still requires root permissions to access, making the symlink irrelevant. 
