### PR TITLE
add config playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ A playbook is provided to upgrade K3s on all nodes in the cluster. To use it, up
 ansible-playbook playbook/upgrade.yml -i inventory.yml
 ```
 
+## Re-applying system configuration
+
+A playbook is provided to re-apply system configuration settings of the nodes in your cluster:
+
+```bash
+ansible-playbook playbook/config.yml -i inventory.yml
+```
+
 ## Airgap Install
 
 Airgap installation is supported via the `airgap_dir` variable. This variable should be set to the path of a directory containing the K3s binary and images. The release artifacts can be downloaded from the [K3s Releases](https://github.com/k3s-io/k3s/releases). You must download the appropriate images for you architecture (any of the compression formats will work).

--- a/playbook/config.yml
+++ b/playbook/config.yml
@@ -1,0 +1,8 @@
+---
+- name: Cluster prep
+  hosts: k3s_cluster
+  gather_facts: true
+  become: true
+  roles:
+    - role: prereq
+    - role: raspberrypi


### PR DESCRIPTION
Re-apply system configuration setting playbook added. User may have a case when a node was added manually to the cluster. And so user didn't pay close attention applying some/most of the configuration settings. This change should allow bringing such nodes in-sync with those configured by the script initially while skipping K3s installation steps.

#### Changes ####

#### Linked Issues ####