### PR TITLE
Ansible Galaxy support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+---
+name: Build
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  test:
+    name: Build Ansible Galaxy collection artifact.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible
+
+      - name: Build artifact.
+        run: ansible-galaxy collection build
+
+      - name: Upload artifact.
+        uses: actions/upload-artifact@v4
+        with:
+          name: galaxy-collection
+          path: k3s-orchestration-*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+venv
+.venv
 .vscode
 .vagrant
 inventory.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# `k3s-ansible` changelog (`k3s.orchestration`)
+## 1.0.0
+Initial Release

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,74 @@
+---
+### REQUIRED
+# The namespace of the collection. This can be a company/brand/organization or product namespace under which all
+# content lives. May only contain alphanumeric lowercase characters and underscores. Namespaces cannot start with
+# underscores or numbers and cannot contain consecutive underscores
+namespace: k3s
+
+# The name of the collection. Has the same character restrictions as 'namespace'
+name: orchestration
+
+# The version of the collection. Must be compatible with semantic versioning
+version: 1.0.0
+
+# The path to the Markdown (.md) readme file. This path is relative to the root of the collection
+readme: README.md
+
+# A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
+# @nicks:irc/im.site#channel'
+authors:
+  - Julien DOCHE <julien.doche@gmail.com>
+  - Derek Nola <derek.nola@suse.com>
+  - David Putzolu <dputzolu@gmail.com>
+  - Jeff Geerling <geerlingguy@mac.com>
+  - Staf Wagemakers <staf@wagemakers.be>
+  - Vincent RABAH <vincent.rabah@gmail.com>
+
+### OPTIONAL but strongly recommended
+# A short summary description of the collection
+description: Build a Kubernetes cluster using K3s via Ansible
+
+# Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
+# accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
+license:
+  - Apache-2.0
+
+# The path to the license file for the collection. This path is relative to the root of the collection. This key is
+# mutually exclusive with 'license'
+# license_file: ''
+
+# A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
+# requirements as 'namespace' and 'name'
+tags: ['infrastructure', 'linux', 'tools']
+
+# Collections that this collection requires to be installed for it to be usable. The key of the dict is the
+# collection label 'namespace.name'. The value is a version range
+# L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
+# range specifiers can be set and are separated by ','
+dependencies:
+  community.general: ">=7.0.0"
+  ansible.posix: ">=1.5.0"
+
+# The URL of the originating SCM repository
+repository: https://github.com/k3s-io/k3s-ansible
+
+# The URL to any online docs
+documentation: https://github.com/k3s-io/k3s-ansible/blob/master/README.md
+
+# The URL to the homepage of the collection/project
+homepage: https://github.com/k3s-io/k3s-ansible
+
+# The URL to the collection issue tracker
+issues: https://github.com/k3s-io/k3s-ansible/issues
+
+# A list of file glob-like patterns used to filter any files or directories that should not be included in the build
+# artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This
+# uses 'fnmatch' to match the files or directories. Some directories and files like 'galaxy.yml', '*.pyc', '*.retry',
+# and '.git' are always filtered. Mutually exclusive with 'manifest'
+build_ignore: []
+# A dict controlling use of manifest directives used in building the collection artifact. The key 'directives' is a
+# list of MANIFEST.in style
+# L(directives,https://packaging.python.org/en/latest/guides/using-manifest-in/#manifest-in-commands). The key
+# 'omit_default_directives' is a boolean that controls whether the default directives are used. Mutually exclusive
+# with 'build_ignore'
+# manifest: null

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.14.0"


### PR DESCRIPTION
AWX (~~Ansible Tower~~ Ansible Automation Controller) requires dependencies to have support for `ansible-galaxy`. To be able to these roles on my AWX installation, I've added some metadata necessary to use the project as a Galaxy collection. It has been tested to work correctly in [this playbook](https://github.com/ShamrockSystems/awx-metal-chore/blob/473200f8ec720b75262ca0e23faf88eea80c8422/playbooks/install-k3s.yaml).

In the future, a workflow may be created to support automatic build and upload to Ansible Galaxy on tag/release.

I chose the version number (1.0.0) arbitrarily. If there's any objections please do tell. Additionally, it might be worth running the `Build` workflow on PRs, but it isn't configured to do so right now.

#### Changes ####
- Added necessary files for Ansible Galaxy support (`galaxy.yml`, `runtime.yml`, `CHANGELOG.md`)
- Added common Python `venv` directories to `.gitignore`
- Created new GitHub Actions workflow to build Ansible Galaxy collection (mostly for testing, this does not include release workflows)

#### Linked Issues ####
#251 
