### PR TITLE
k3s agent - Fix bad reference to k3s-agent.service.env in k3s-agent.service file

### DIFF
--- a/roles/k3s_agent/templates/k3s-agent.service.j2
+++ b/roles/k3s_agent/templates/k3s-agent.service.j2
@@ -11,7 +11,7 @@ WantedBy=multi-user.target
 Type=notify
 EnvironmentFile=-/etc/default/%N
 EnvironmentFile=-/etc/sysconfig/%N
-EnvironmentFile=-/etc/systemd/system/k3s.service.env
+EnvironmentFile=-/etc/systemd/system/k3s-agent.service.env
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
Template **k3s-agent.service.j2** in **k3s-agent** role references bad service environment file.

This causes agent to not be aware of defined environment variables.

#### Changes ####
Fix name in agent service template:
```
EnvironmentFile=-/etc/systemd/system/k3s.service.env
# Replacement
EnvironmentFile=-/etc/systemd/system/k3s-agent.service.env
```
