### PR TITLE
Fix unexpected behaviour when `kubeconfig` is set

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -119,9 +119,8 @@
           ansible.builtin.shell: |
             TFILE=$(mktemp)
             KUBECONFIG={{ kubeconfig }} kubectl config set-context k3s-ansible --user=k3s-ansible --cluster=k3s-ansible
-            KUBECONFIG={{ kubeconfig }}:~/.kube/config kubectl config view --flatten > ${TFILE}
-            mv ${TFILE} ~/.kube/config
-            rm {{ kubeconfig }}
+            KUBECONFIG={{ kubeconfig }} kubectl config view --flatten > ${TFILE}
+            mv ${TFILE} {{ kubeconfig }}
           delegate_to: 127.0.0.1
           become: false
           register: mv_result


### PR DESCRIPTION
As detailed in https://github.com/k3s-io/k3s-ansible/issues/295, this merge request fixes the issue that if `kubeconfig` is set to a value other than `~/.kube/config`, then:

- `~/.kube/config` is modified.
- No file at `{{ kubeconfig }}` is created.
- Any existing file at `{{ kubeconfig }}` is deleted.

#### Changes ####

- Do not append hard-coded `KUBECONFIG` path to `kubectl` commands.
- Do not remove `{{ kubeconfig }}`.

#### Linked Issues ####

https://github.com/k3s-io/k3s-ansible/issues/295