### PR TITLE
Check K3s installed version before download tasks

### DIFF
--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -1,24 +1,39 @@
 ---
-# If airgapped, all K3s artifacts are already on the node.
-- name: Download K3s install script
-  when: airgap_dir is undefined
-  ansible.builtin.get_url:
-    url: https://get.k3s.io/
-    timeout: 120
-    dest: /usr/local/bin/k3s-install.sh
-    owner: root
-    group: root
-    mode: 0755
+- name: Get k3s installed version
+  ansible.builtin.command: k3s --version
+  register: k3s_version_output
+  changed_when: false
+  ignore_errors: true
 
-- name: Download K3s binary
-  when: airgap_dir is undefined
-  ansible.builtin.command:
-    cmd: /usr/local/bin/k3s-install.sh
-  environment:
-    INSTALL_K3S_SKIP_START: "true"
-    INSTALL_K3S_VERSION: "{{ k3s_version }}"
-    INSTALL_K3S_EXEC: "agent"
-  changed_when: true
+- name: Set k3s installed version
+  when: k3s_version_output.rc == 0
+  ansible.builtin.set_fact:
+    installed_k3s_version: "{{ k3s_version_output.stdout_lines[0].split(' ')[2] }}"
+
+# If airgapped, all K3s artifacts are already on the node.
+# We should be downloading and installing the newer version only if we are in one of the following cases :
+#   - we couldn't get k3s installed version in the first task of this role
+#   - the installed version of K3s on the nodes is older than the requested version in ansible vars
+- name: Download artefact only if needed
+  when: k3s_version_output.rc != 0 or installed_k3s_version is version(k3s_version, '<') and airgap_dir is undefined
+  block:
+    - name: Download K3s install script
+      ansible.builtin.get_url:
+        url: https://get.k3s.io/
+        timeout: 120
+        dest: /usr/local/bin/k3s-install.sh
+        owner: root
+        group: root
+        mode: 0755
+
+    - name: Download K3s binary
+      ansible.builtin.command:
+        cmd: /usr/local/bin/k3s-install.sh
+      environment:
+        INSTALL_K3S_SKIP_START: "true"
+        INSTALL_K3S_VERSION: "{{ k3s_version }}"
+        INSTALL_K3S_EXEC: "agent"
+      changed_when: true
 
 - name: Copy K3s service file
   register: k3s_agent_service

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -1,23 +1,38 @@
 ---
-# If airgapped, all K3s artifacts are already on the node.
-- name: Download K3s install script
-  when: airgap_dir is undefined
-  ansible.builtin.get_url:
-    url: https://get.k3s.io/
-    timeout: 120
-    dest: /usr/local/bin/k3s-install.sh
-    owner: root
-    group: root
-    mode: 0755
+- name: Get k3s installed version
+  ansible.builtin.command: k3s --version
+  register: k3s_version_output
+  changed_when: false
+  ignore_errors: true
 
-- name: Download K3s binary
-  when: airgap_dir is undefined
-  ansible.builtin.command:
-    cmd: /usr/local/bin/k3s-install.sh
-  environment:
-    INSTALL_K3S_SKIP_START: "true"
-    INSTALL_K3S_VERSION: "{{ k3s_version }}"
-  changed_when: true
+- name: Set k3s installed version
+  when: k3s_version_output.rc == 0
+  ansible.builtin.set_fact:
+    installed_k3s_version: "{{ k3s_version_output.stdout_lines[0].split(' ')[2] }}"
+
+# If airgapped, all K3s artifacts are already on the node.
+# We should be downloading and installing the newer version only if we are in one of the following cases :
+#   - we couldn't get k3s installed version in the first task of this role
+#   - the installed version of K3s on the nodes is older than the requested version in ansible vars
+- name: Download artefact only if needed
+  when: k3s_version_output.rc != 0 or installed_k3s_version is version(k3s_version, '<') and airgap_dir is undefined
+  block:
+    - name: Download K3s install script
+      ansible.builtin.get_url:
+        url: https://get.k3s.io/
+        timeout: 120
+        dest: /usr/local/bin/k3s-install.sh
+        owner: root
+        group: root
+        mode: 0755
+
+    - name: Download K3s binary
+      ansible.builtin.command:
+        cmd: /usr/local/bin/k3s-install.sh
+      environment:
+        INSTALL_K3S_SKIP_START: "true"
+        INSTALL_K3S_VERSION: "{{ k3s_version }}"
+      changed_when: true
 
 - name: Add K3s autocomplete to user bashrc
   ansible.builtin.lineinfile:

--- a/roles/k3s_upgrade/tasks/main.yml
+++ b/roles/k3s_upgrade/tasks/main.yml
@@ -1,34 +1,48 @@
 ---
 # with_fileglob doesn't work with remote_src, it tries to find the file on the
 # local control-plane instead of the remote host. Shell supports wildcards.
-- name: Save current K3s service
-  ansible.builtin.shell:
-    cmd: "cp {{ systemd_dir }}/k3s*.service /tmp/"
-  changed_when: true
+- name: Get k3s installed version
+  ansible.builtin.command: k3s --version
+  register: k3s_version_output
+  changed_when: false
 
-- name: Install new K3s Version
-  ansible.builtin.command:
-    cmd: /usr/local/bin/k3s-install.sh
-  environment:
-    INSTALL_K3S_SKIP_START: "true"
-    INSTALL_K3S_VERSION: "{{ k3s_version }}"
-  changed_when: true
+- name: Set k3s installed version
+  ansible.builtin.set_fact:
+    installed_k3s_version: "{{ k3s_version_output.stdout_lines[0].split(' ')[2] }}"
 
-- name: Restore K3s service
-  ansible.builtin.shell:
-    cmd: "mv /tmp/k3s*.service {{ systemd_dir }}/"
-  changed_when: true
+# We should be downloading and installing the newer version only if we are in the following case :
+#   - the installed version of K3s on the nodes is older than the requested version in ansible vars
+- name: Update node only if needed
+  when: installed_k3s_version is version(k3s_version, '<')
+  block:
+    - name: Save current K3s service
+      ansible.builtin.shell:
+        cmd: "cp {{ systemd_dir }}/k3s*.service /tmp/"
+      changed_when: true
 
-- name: Restart K3s service [server]
-  when: "'server' in group_names"
-  ansible.builtin.systemd:
-    state: restarted
-    daemon_reload: true
-    name: k3s
+    - name: Install new K3s Version
+      ansible.builtin.command:
+        cmd: /usr/local/bin/k3s-install.sh
+      environment:
+        INSTALL_K3S_SKIP_START: "true"
+        INSTALL_K3S_VERSION: "{{ k3s_version }}"
+      changed_when: true
 
-- name: Restart K3s service [agent]
-  when: "'agent' in group_names"
-  ansible.builtin.systemd:
-    state: restarted
-    daemon_reload: true
-    name: k3s-agent
+    - name: Restore K3s service
+      ansible.builtin.shell:
+        cmd: "mv /tmp/k3s*.service {{ systemd_dir }}/"
+      changed_when: true
+
+    - name: Restart K3s service [server]
+      when: "'server' in group_names"
+      ansible.builtin.systemd:
+        state: restarted
+        daemon_reload: true
+        name: k3s
+
+    - name: Restart K3s service [agent]
+      when: "'agent' in group_names"
+      ansible.builtin.systemd:
+        state: restarted
+        daemon_reload: true
+        name: k3s-agent


### PR DESCRIPTION
#### Changes ####

- [Agent : Download artefact only if needed](roles/k3s_agent/tasks/main.yml#L13)
- [Server : Download artefact only if needed](roles/k3s_server/tasks/main.yml#L13)
- [Upgrade : Upgrade node only if needed](roles/k3s_upgrade/tasks/main.yml#L14)

#### Linked Issues ####

 #264  : k3s_server and k3s_agent tasks are not idempotent
