### PR TITLE
Enable skipping bootcmd verification in Raspberry PI

### DIFF
--- a/inventory-sample.yml
+++ b/inventory-sample.yml
@@ -29,6 +29,7 @@ k3s_cluster:
     # extra_manifests: [ '/path/to/manifest1.yaml', '/path/to/manifest2.yaml' ]
     # airgap_dir: /tmp/k3s-airgap-images
     # user_kubectl: true, by default kubectl is symlinked and configured for use by ansible_user. Set to false to only kubectl via root user.
+    # skip_rpi_cmdline: true # normal instalations of raspberry don't require this, when set it spiks the checks of
     # server_config_yaml:  |
       # This is now an inner yaml file. Maintain the indentation.
       # YAML here will be placed as the content of /etc/rancher/k3s/config.yaml

--- a/roles/raspberrypi/tasks/prereq/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/prereq/Ubuntu.yml
@@ -1,5 +1,6 @@
 ---
 - name: Enable cgroup via boot commandline if not already enabled
+  when: skip_rpi_cmdline is undefined
   ansible.builtin.lineinfile:
     path: /boot/firmware/cmdline.txt
     backrefs: true


### PR DESCRIPTION
#### Changes ####
Add `skip_rpi_cmdline` variable to enable skipping the mutation of `/boot/firmware/cmdline.txt`vin Ubuntu Raspberry.

In some scenarios (ie: network boot) the firmware and kernel is loaded during booting.
#### Linked Issues ####