### PR TITLE
Add a minimum ansible core check

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Enforce minimum Ansible version
+  ansible.builtin.assert:
+    that:
+      - ansible_version.full is version('2.14', '>=')
+    msg: "Minimum ansible-core version required is 2.14"
+
 - name: Install Dependent Ubuntu Packages
   when: ansible_distribution in ['Ubuntu']
   ansible.builtin.apt:


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Changes ####
- Adds a minimum ansbile-core version check for greater than 2.14.0. Several issues keep popping up around users seeing errors from using old 2.10.X versions. 
#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/257
