### PR TITLE
fix: skip cgroups when cmdline.txt is not present

### DIFF
--- a/roles/raspberrypi/tasks/prereq/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/prereq/Ubuntu.yml
@@ -1,6 +1,6 @@
 ---
 - name: Enable cgroup via boot commandline if not already enabled
-  when: lookup('fileglob', '/boot/firmware/cmdline.txt', errors='warn') | length == 0
+  when: lookup('fileglob', '/boot/firmware/cmdline.txt', errors='warn') | length > 0
   ansible.builtin.lineinfile:
     path: /boot/firmware/cmdline.txt
     backrefs: true


### PR DESCRIPTION
#### Changes ####
Skip step `Enable cgroup via boot commandline if not already enabled`  when the file is not present.

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/312