### PR TITLE
feat: Add support using Docker runtime & allow setting of node name per node

### DIFF
--- a/inventory-sample.yml
+++ b/inventory-sample.yml
@@ -38,3 +38,4 @@ k3s_cluster:
       # Containerd can be configured to connect to private registries and use them to pull images as needed by the kubelet.
       # YAML here will be placed as the content of /etc/rancher/k3s/registries.yaml
       # See https://docs.k3s.io/installation/private-registry
+    # use_docker_runtime: false, by default containerd is used as the runtime. Set to true to install docker and use it as the k3s runtime

--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -25,6 +25,25 @@
         group: root
         mode: 0755
 
+    - name: Download install docker script
+      delegate_to: localhost
+      ansible.builtin.get_url:
+        # don't use the docker provided script https://get.docker.com as it doesn't seem to work well with k3s
+        url: https://releases.rancher.com/install-docker/20.10.sh
+        timeout: 120
+        dest: "{{ airgap_dir }}/install-docker.sh"
+        mode: 0755
+      when: use_docker_runtime
+
+    - name: Distribute install docker script
+      ansible.builtin.copy:
+        src: "{{ airgap_dir }}/install-docker.sh"
+        dest: /usr/local/bin/install-docker.sh
+        owner: root
+        group: root
+        mode: 0755
+      when: use_docker_runtime
+
     - name: Distribute K3s binary
       ansible.builtin.copy:
         src: "{{ airgap_dir }}/k3s"
@@ -108,6 +127,12 @@
             - "{{ airgap_dir }}/k3s-airgap-images-arm.tar.gz"
             - "{{ airgap_dir }}/k3s-airgap-images-arm.tar"
           skip: true
+
+    - name: Run install docker script
+      ansible.builtin.command:
+        cmd: /usr/local/bin/install-docker.sh
+      changed_when: true
+      when: use_docker_runtime
 
     - name: Run K3s Install [server]
       ansible.builtin.command:

--- a/roles/k3s_agent/defaults/main.yml
+++ b/roles/k3s_agent/defaults/main.yml
@@ -2,3 +2,5 @@
 k3s_server_location: "/var/lib/rancher/k3s"
 systemd_dir: "/etc/systemd/system"
 api_port: 6443
+use_docker_runtime: false
+node_name: "{{ inventory_hostname }}"

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -10,11 +10,23 @@
   ansible.builtin.set_fact:
     installed_k3s_version: "{{ k3s_version_output.stdout_lines[0].split(' ')[2] }}"
 
+- name: Get docker installed version
+  ansible.builtin.command: docker --version
+  register: docker_version_output
+  changed_when: false
+  ignore_errors: true
+  when: use_docker_runtime
+
+- name: Set docker installed version
+  when: use_docker_runtime and docker_version_output.rc == 0
+  ansible.builtin.set_fact:
+    installed_docker_version: "{{ docker_version_output.stdout_lines[0].split(' ')[2] }}"
+
 # If airgapped, all K3s artifacts are already on the node.
 # We should be downloading and installing the newer version only if we are in one of the following cases :
 #   - we couldn't get k3s installed version in the first task of this role
 #   - the installed version of K3s on the nodes is older than the requested version in ansible vars
-- name: Download artifact only if needed
+- name: Download k3s artifact only if needed
   when: k3s_version_output.rc != 0 or installed_k3s_version is version(k3s_version, '<') and airgap_dir is undefined
   block:
     - name: Download K3s install script
@@ -26,13 +38,31 @@
         group: root
         mode: 0755
 
-    - name: Download K3s binary
+    - name: Run K3S Install
       ansible.builtin.command:
         cmd: /usr/local/bin/k3s-install.sh
       environment:
         INSTALL_K3S_SKIP_START: "true"
         INSTALL_K3S_VERSION: "{{ k3s_version }}"
         INSTALL_K3S_EXEC: "agent"
+      changed_when: true
+
+- name: Download docker artifact only if needed
+  when: use_docker_runtime and docker_version_output.rc != 0 and airgap_dir is undefined
+  block:
+    - name: Download docker install script
+      ansible.builtin.get_url:
+        # don't use the docker provided script https://get.docker.com as it doesn't seem to work well with k3s
+        url: https://releases.rancher.com/install-docker/20.10.sh
+        timeout: 120
+        dest: /usr/local/bin/install-docker.sh
+        owner: root
+        group: root
+        mode: 0755
+
+    - name: Run docker install script
+      ansible.builtin.command:
+        cmd: /usr/local/bin/install-docker.sh
       changed_when: true
 
 - name: Copy K3s service file

--- a/roles/k3s_agent/templates/k3s-agent.service.j2
+++ b/roles/k3s_agent/templates/k3s-agent.service.j2
@@ -26,4 +26,4 @@ RestartSec=5s
 ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service'
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s agent --data-dir {{ k3s_server_location }} --server https://{{ api_endpoint }}:{{ api_port }} --token {{ token }} {{ extra_agent_args }}
+ExecStart=/usr/local/bin/k3s agent --node-name {{ node_name }} --data-dir {{ k3s_server_location }} --server https://{{ api_endpoint }}:{{ api_port }} --token {{ token }} {{ '--docker' if use_docker_runtime else '' }} {{ extra_agent_args }}

--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -5,3 +5,5 @@ api_port: 6443
 kubeconfig: ~/.kube/config.new
 user_kubectl: true
 cluster_context: k3s-ansible
+use_docker_runtime: false
+node_name: "{{ inventory_hostname }}"

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -10,11 +10,23 @@
   ansible.builtin.set_fact:
     installed_k3s_version: "{{ k3s_version_output.stdout_lines[0].split(' ')[2] }}"
 
+- name: Get docker installed version
+  ansible.builtin.command: docker --version
+  register: docker_version_output
+  changed_when: false
+  ignore_errors: true
+  when: use_docker_runtime
+
+- name: Set docker installed version
+  when: use_docker_runtime and docker_version_output.rc == 0
+  ansible.builtin.set_fact:
+    installed_docker_version: "{{ docker_version_output.stdout_lines[0].split(' ')[2] }}"
+
 # If airgapped, all K3s artifacts are already on the node.
 # We should be downloading and installing the newer version only if we are in one of the following cases :
 #   - we couldn't get k3s installed version in the first task of this role
 #   - the installed version of K3s on the nodes is older than the requested version in ansible vars
-- name: Download artifact only if needed
+- name: Download k3s artifact only if needed
   when: k3s_version_output.rc != 0 or installed_k3s_version is version(k3s_version, '<') and airgap_dir is undefined
   block:
     - name: Download K3s install script
@@ -26,12 +38,30 @@
         group: root
         mode: 0755
 
-    - name: Download K3s binary
+    - name: Run K3S Install
       ansible.builtin.command:
         cmd: /usr/local/bin/k3s-install.sh
       environment:
         INSTALL_K3S_SKIP_START: "true"
         INSTALL_K3S_VERSION: "{{ k3s_version }}"
+      changed_when: true
+
+- name: Download docker artifact only if needed
+  when: use_docker_runtime and docker_version_output.rc != 0 and airgap_dir is undefined
+  block:
+    - name: Download docker install script
+      ansible.builtin.get_url:
+        # don't use the docker provided script https://get.docker.com as it doesn't seem to work well with k3s
+        url: https://releases.rancher.com/install-docker/20.10.sh
+        timeout: 120
+        dest: /usr/local/bin/install-docker.sh
+        owner: root
+        group: root
+        mode: 0755
+
+    - name: Run docker install script
+      ansible.builtin.command:
+        cmd: /usr/local/bin/install-docker.sh
       changed_when: true
 
 - name: Add K3s autocomplete to user bashrc

--- a/roles/k3s_server/templates/k3s-cluster-init.service.j2
+++ b/roles/k3s_server/templates/k3s-cluster-init.service.j2
@@ -25,4 +25,4 @@ Restart=always
 RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s server --cluster-init --data-dir {{ k3s_server_location }} --token {{ token }} {{ extra_server_args }} 
+ExecStart=/usr/local/bin/k3s server --cluster-init --node-name {{ node_name }} --data-dir {{ k3s_server_location }} --token {{ token }} {{ '--docker' if use_docker_runtime else '' }} {{ extra_server_args }}

--- a/roles/k3s_server/templates/k3s-ha.service.j2
+++ b/roles/k3s_server/templates/k3s-ha.service.j2
@@ -25,4 +25,4 @@ Restart=always
 RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s server --data-dir {{ k3s_server_location }} --server https://{{ api_endpoint }}:{{ api_port }} --token {{ token }} {{ extra_server_args }} 
+ExecStart=/usr/local/bin/k3s server --node-name {{ node_name }} --data-dir {{ k3s_server_location }} --server https://{{ api_endpoint }}:{{ api_port }} --token {{ token }} {{ '--docker' if use_docker_runtime else '' }} {{ extra_server_args }}

--- a/roles/k3s_server/templates/k3s-single.service.j2
+++ b/roles/k3s_server/templates/k3s-single.service.j2
@@ -25,4 +25,4 @@ Restart=always
 RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s server --data-dir {{ k3s_server_location }} --token {{ token }} {{ extra_server_args }} 
+ExecStart=/usr/local/bin/k3s server --node-name {{ node_name }} --data-dir {{ k3s_server_location }} --token {{ token }} {{ '--docker' if use_docker_runtime else '' }} {{ extra_server_args }}


### PR DESCRIPTION
#### Changes ####

Add support using Docker runtime.
Allow setting of node name per node.

#### Linked Issues ####

- No linked issue, these were just somethings I noticed come up when testing.
  - When passing `--docker` for `extra_server_args` and `extra_agent_args` it causes issues as docker was not installed.
  - When using multiple hosts there was no easy to set the node name per node.
