### PR TITLE
Apply noqa and fix line length limit. Achieve ansible-lint production profile

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,7 +3,7 @@ extends: default
 
 rules:
   line-length:
-    max: 120
+    max: 180
     level: warning
   truthy:
     allowed-values: ['true', 'false']

--- a/inventory-sample.yml
+++ b/inventory-sample.yml
@@ -19,22 +19,25 @@ k3s_cluster:
     extra_server_args: ""
     extra_agent_args: ""
 
-  # Optional vars
+    # Optional vars
+
     # cluster_context: k3s-ansible
     # api_port: 6443
     # k3s_server_location: /var/lib/rancher/k3s
     # systemd_dir: /etc/systemd/system
     # extra_service_envs: [ 'ENV_VAR1=VALUE1', 'ENV_VAR2=VALUE2' ]
+    # user_kubectl: true, by default kubectl is symlinked and configured for use by ansible_user. Set to false to only kubectl via root user.
+
     # Manifests or Airgap should be either full paths or relative to the playbook directory.
     # List of locally available manifests to apply to the cluster, useful for PVCs or Traefik modifications.
     # extra_manifests: [ '/path/to/manifest1.yaml', '/path/to/manifest2.yaml' ]
     # airgap_dir: /tmp/k3s-airgap-images
-    # user_kubectl: true, by default kubectl is symlinked and configured for use by ansible_user. Set to false to only kubectl via root user.
+
     # server_config_yaml:  |
-      # This is now an inner yaml file. Maintain the indentation.
-      # YAML here will be placed as the content of /etc/rancher/k3s/config.yaml
-      # See https://docs.k3s.io/installation/configuration#configuration-file
+    #   This is now an inner yaml file. Maintain the indentation.
+    #   YAML here will be placed as the content of /etc/rancher/k3s/config.yaml
+    #   See https://docs.k3s.io/installation/configuration#configuration-file
     # registries_config_yaml:  |
-      # Containerd can be configured to connect to private registries and use them to pull images as needed by the kubelet.
-      # YAML here will be placed as the content of /etc/rancher/k3s/registries.yaml
-      # See https://docs.k3s.io/installation/private-registry
+    #   Containerd can be configured to connect to private registries and use them to pull images as needed by the kubelet.
+    #   YAML here will be placed as the content of /etc/rancher/k3s/registries.yaml
+    #   See https://docs.k3s.io/installation/private-registry

--- a/roles/k3s_agent/defaults/main.yml
+++ b/roles/k3s_agent/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-k3s_server_location: "/var/lib/rancher/k3s"
-systemd_dir: "/etc/systemd/system"
-api_port: 6443
+k3s_server_location: "/var/lib/rancher/k3s"  # noqa var-naming[no-role-prefix]
+systemd_dir: "/etc/systemd/system"  # noqa var-naming[no-role-prefix]
+api_port: 6443  # noqa var-naming[no-role-prefix]

--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 k3s_server_location: "/var/lib/rancher/k3s"
-systemd_dir: "/etc/systemd/system"
-api_port: 6443
-kubeconfig: ~/.kube/config.new
-user_kubectl: true
-cluster_context: k3s-ansible
+systemd_dir: "/etc/systemd/system"  # noqa var-naming[no-role-prefix]
+api_port: 6443  # noqa var-naming[no-role-prefix]
+kubeconfig: ~/.kube/config.new  # noqa var-naming[no-role-prefix]
+user_kubectl: true  # noqa var-naming[no-role-prefix]
+cluster_context: k3s-ansible  # noqa var-naming[no-role-prefix]

--- a/roles/k3s_upgrade/defaults/main.yml
+++ b/roles/k3s_upgrade/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-systemd_dir: /etc/systemd/system
+systemd_dir: /etc/systemd/system  # noqa var-naming[no-role-prefix]

--- a/roles/prereq/defaults/main.yml
+++ b/roles/prereq/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-api_port: 6443
+api_port: 6443  # noqa var-naming[no-role-prefix]

--- a/roles/prereq/vars/main.yml
+++ b/roles/prereq/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-cluster_cidr: "{{ (server_config_yaml | from_yaml)['cluster-cidr'] | default('10.42.0.0/16') }}"
-service_cidr: "{{ (server_config_yaml | from_yaml)['service-cidr'] | default('10.43.0.0/16') }}"
+cluster_cidr: "{{ (server_config_yaml | from_yaml)['cluster-cidr'] | default('10.42.0.0/16') }}"  # noqa var-naming[no-role-prefix]
+service_cidr: "{{ (server_config_yaml | from_yaml)['service-cidr'] | default('10.43.0.0/16') }}"  # noqa var-naming[no-role-prefix]

--- a/roles/raspberrypi/tasks/prereq/Archlinux.yml
+++ b/roles/raspberrypi/tasks/prereq/Archlinux.yml
@@ -2,8 +2,7 @@
 - name: Enable cgroup via boot commandline if not already enabled
   ansible.builtin.lineinfile:
     path: /boot/boot.txt
-    # yamllint disable-line rule:line-length
-    search_string: setenv bootargs console=ttyS1,115200 console=tty0 root=PARTUUID=${uuid} rw rootwait smsc95xx.macaddr="${usbethaddr}"
-    # yamllint disable-line rule:line-length
-    line: setenv bootargs console=ttyS1,115200 console=tty0 root=PARTUUID=${uuid} rw rootwait smsc95xx.macaddr="${usbethaddr}" cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory
+    regexp: '^(setenv bootargs console=ttyS1,115200 console=tty0 root=PARTUUID=\${uuid} rw rootwait smsc95xx.macaddr="\${usbethaddr}")'
+    line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
+    backrefs: true
   notify: Regenerate bootloader image


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Changes ####
- Add `no-qa` to most default vars, as we don't prefix them with `k3s_server` and don't plan to. 
- Adjust the line-length warning to 180... 120 was too short
- Comment indentation fixes

ansible-lint now reports as `production` instead of `min`

#### Linked Issues ####
Partially addresses https://github.com/k3s-io/k3s-ansible/issues/321

