### PR TITLE
Implement compatible yamllint, make octals explicit

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,5 @@
 ---
 warn_list:
- - var-naming[no-role-prefix]
- - yaml[comments-indentation]
- - yaml[line-length]
+  - var-naming[no-role-prefix]
+  - yaml[comments-indentation]
+  - yaml[line-length]

--- a/.yamllint
+++ b/.yamllint
@@ -6,4 +6,12 @@ rules:
     max: 180
     level: warning
   truthy:
-    allowed-values: ['true', 'false']
+    allowed-values: ["true", "false"]
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false

--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -15,7 +15,7 @@
         url: https://get.k3s.io/
         timeout: 120
         dest: "{{ airgap_dir }}/k3s-install.sh"
-        mode: 0755
+        mode: "0755"
 
     - name: Distribute K3s install script
       ansible.builtin.copy:
@@ -23,7 +23,7 @@
         dest: /usr/local/bin/k3s-install.sh
         owner: root
         group: root
-        mode: 0755
+        mode: "0755"
 
     - name: Distribute K3s binary
       ansible.builtin.copy:
@@ -31,7 +31,7 @@
         dest: /usr/local/bin/k3s
         owner: root
         group: root
-        mode: 0755
+        mode: "0755"
 
     - name: Distribute K3s SELinux RPM
       ansible.builtin.copy:
@@ -39,7 +39,7 @@
         dest: /tmp/
         owner: root
         group: root
-        mode: 0755
+        mode: "0755"
       with_fileglob:
         - "{{ airgap_dir }}/k3s-selinux*.rpm"
       register: selinux_copy
@@ -57,7 +57,7 @@
     - name: Make images directory
       ansible.builtin.file:
         path: "/var/lib/rancher/k3s/agent/images/"
-        mode: 0755
+        mode: "0755"
         state: directory
 
     - name: Determine Architecture
@@ -71,7 +71,7 @@
         dest: /var/lib/rancher/k3s/agent/images/{{ item | basename }}
         owner: root
         group: root
-        mode: 0755
+        mode: "0755"
       with_first_found:
         - files:
             - "{{ airgap_dir }}/k3s-airgap-images-amd64.tar.zst"
@@ -86,7 +86,7 @@
         dest: /var/lib/rancher/k3s/agent/images/{{ item | basename }}
         owner: root
         group: root
-        mode: 0755
+        mode: "0755"
       with_first_found:
         - files:
             - "{{ airgap_dir }}/k3s-airgap-images-arm64.tar.zst"
@@ -101,7 +101,7 @@
         dest: /var/lib/rancher/k3s/agent/images/{{ item | basename }}
         owner: root
         group: root
-        mode: 0755
+        mode: "0755"
       with_first_found:
         - files:
             - "{{ airgap_dir }}/k3s-airgap-images-arm.tar.zst"

--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -49,7 +49,7 @@
       when:
         - ansible_os_family == 'RedHat'
         - selinux_copy.skipped is false
-      ansible.builtin.yum:
+      ansible.builtin.dnf:
         name: "{{ selinux_copy.results[0].dest }}"
         state: present
         disable_gpg_check: true

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -24,7 +24,7 @@
         dest: /usr/local/bin/k3s-install.sh
         owner: root
         group: root
-        mode: 0755
+        mode: "0755"
 
     - name: Download K3s binary
       ansible.builtin.command:

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -24,7 +24,7 @@
         dest: /usr/local/bin/k3s-install.sh
         owner: root
         group: root
-        mode: 0755
+        mode: "0755"
 
     - name: Download K3s binary
       ansible.builtin.command:
@@ -46,13 +46,13 @@
     - name: Make config directory
       ansible.builtin.file:
         path: "/etc/rancher/k3s"
-        mode: 0755
+        mode: "0755"
         state: directory
     - name: Copy config values
       ansible.builtin.copy:
         content: "{{ server_config_yaml }}"
         dest: "/etc/rancher/k3s/config.yaml"
-        mode: 0644
+        mode: "0644"
 
 - name: Init first server node
   when: inventory_hostname == groups['server'][0]
@@ -64,7 +64,7 @@
         dest: "{{ systemd_dir }}/k3s.service"
         owner: root
         group: root
-        mode: 0644
+        mode: "0644"
 
     - name: Copy K3s service file [HA]
       when: groups['server'] | length > 1
@@ -73,7 +73,7 @@
         dest: "{{ systemd_dir }}/k3s.service"
         owner: root
         group: root
-        mode: 0644
+        mode: "0644"
 
     - name: Add service environment variables
       when: extra_service_envs is defined
@@ -154,7 +154,7 @@
         dest: "{{ systemd_dir }}/k3s.service"
         owner: root
         group: root
-        mode: 0644
+        mode: "0644"
 
     - name: Enable and check K3s service
       ansible.builtin.systemd:

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -215,7 +215,7 @@
     - name: Make rancher directory
       ansible.builtin.file:
         path: "/var/lib/rancher"
-        mode: 0755
+        mode: "0755"
         state: directory
     - name: Create symlink
       ansible.builtin.file:
@@ -230,13 +230,13 @@
     - name: Make manifests directory
       ansible.builtin.file:
         path: "/var/lib/rancher/k3s/server/manifests"
-        mode: 0700
+        mode: "0700"
         state: directory
     - name: Copy manifests
       ansible.builtin.copy:
         src: "{{ item }}"
         dest: "/var/lib/rancher/k3s/server/manifests"
-        mode: 0600
+        mode: "0600"
       loop: "{{ extra_manifests }}"
 
 - name: Setup optional private registry configuration
@@ -245,10 +245,10 @@
     - name: Make k3s config directory
       ansible.builtin.file:
         path: "/etc/rancher/k3s"
-        mode: 0755
+        mode: "0755"
         state: directory
     - name: Copy config values
       ansible.builtin.copy:
         content: "{{ registries_config_yaml }}"
         dest: "/etc/rancher/k3s/registries.yaml"
-        mode: 0644
+        mode: "0644"


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Changes ####
- Add more rules to yamllint to ensure compatability within ansible-lint
- Cover implicit octals with quotes
- Replace deprecated ansible yum module with dnf
#### Linked Issues ####