### PR TITLE
Add group variables to the prereq role

### DIFF
--- a/roles/prereq/defaults/main.yml
+++ b/roles/prereq/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 api_port: 6443  # noqa var-naming[no-role-prefix]
+server_group: server  # noqa var-naming[no-role-prefix]
+agent_group: agent  # noqa var-naming[no-role-prefix]

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -51,7 +51,7 @@
     - name: If ufw enabled, open etcd ports
       when:
         - ufw_status['stdout'] == "Status':' active"
-        - groups['server'] | length > 1
+        - groups[server_group] | length > 1
       community.general.ufw:
         rule: allow
         port: "2379:2381"
@@ -79,7 +79,7 @@
         immediate: true
 
     - name: If firewalld enabled, open etcd ports
-      when: groups['server'] | length > 1
+      when: groups[server_group] | length > 1
       ansible.posix.firewalld:
         port: "2379-2381/tcp"
         zone: internal
@@ -111,8 +111,8 @@
       loop: >-
         {{
           (
-            groups['server'] | default([])
-            + groups['agent'] | default([])
+            groups[server_group] | default([])
+            + groups[agent_group] | default([])
           )
           | map('extract', hostvars, ['ansible_default_ipv4', 'address'])
           | flatten | unique | list


### PR DESCRIPTION
#331 added support for overriding the `server` and `agent` group names in the `k3s_server` and `k3s_upgrade` roles, but the same changes were not added to the `prereq` role.

#### Changes ####
This PR makes the `server` and `agent` groups configurable in the `prereq` role as well.

#### Linked Issues ####
#327