### PR TITLE
fixed path to playbooks/site.yml

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ def provision(vm, role, node_num)
 
   vm.provision "ansible", run: 'once' do |ansible|
     ansible.compatibility_mode = "2.0"
-    ansible.playbook = "playbook/site.yml"
+    ansible.playbook = "playbooks/site.yml"
     ansible.groups = {
       "server" => NODE_ROLES.grep(/^server/),
       "agent" => NODE_ROLES.grep(/^agent/),


### PR DESCRIPTION
#### Changes ####

Changed the vagrant file's provision function from [ansible.playbook = "playbook/site.yml"](https://github.com/k3s-io/k3s-ansible/blob/master/Vagrantfile#L22)  to ... "playbooks/site.yaml"

#### Linked Issues ####

https://github.com/k3s-io/k3s-ansible/issues/336