### PR TITLE
Update required ansible to >=2.15

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Changes ####
- Ansible 2.14 is now EOL, with ansible lint now failing around the enforcement of >= 2.14
- Moved to minimum version of 2.15 ansible. 

#### Linked Issues ####