### PR TITLE
Expose INSTALL_K3S_SKIP_SELINUX_RPM

### DIFF
--- a/roles/k3s_agent/defaults/main.yml
+++ b/roles/k3s_agent/defaults/main.yml
@@ -2,3 +2,4 @@
 k3s_server_location: "/var/lib/rancher/k3s"  # noqa var-naming[no-role-prefix]
 systemd_dir: "/etc/systemd/system"  # noqa var-naming[no-role-prefix]
 api_port: 6443  # noqa var-naming[no-role-prefix]
+k3s_skip_selinux_rpm: "false"

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -32,6 +32,7 @@
       environment:
         INSTALL_K3S_SKIP_START: "true"
         INSTALL_K3S_VERSION: "{{ k3s_version }}"
+        INSTALL_K3S_SKIP_SELINUX_RPM: "{{ k3s_skip_selinux_rpm }}"
         INSTALL_K3S_EXEC: "agent"
       changed_when: true
 

--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -7,3 +7,4 @@ user_kubectl: true  # noqa var-naming[no-role-prefix]
 cluster_context: k3s-ansible  # noqa var-naming[no-role-prefix]
 server_group: server  # noqa var-naming[no-role-prefix]
 agent_group: agent  # noqa var-naming[no-role-prefix]
+k3s_skip_selinux_rpm: "false"

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -32,6 +32,7 @@
       environment:
         INSTALL_K3S_SKIP_START: "true"
         INSTALL_K3S_VERSION: "{{ k3s_version }}"
+        INSTALL_K3S_SKIP_SELINUX_RPM: "{{ k3s_skip_selinux_rpm }}"
       changed_when: true
 
 - name: Add K3s autocomplete to user bashrc

--- a/roles/k3s_upgrade/defaults/main.yml
+++ b/roles/k3s_upgrade/defaults/main.yml
@@ -2,3 +2,4 @@
 systemd_dir: /etc/systemd/system  # noqa var-naming[no-role-prefix]
 server_group: server  # noqa var-naming[no-role-prefix]
 agent_group: agent  # noqa var-naming[no-role-prefix]
+k3s_skip_selinux_rpm: "false"

--- a/roles/k3s_upgrade/tasks/main.yml
+++ b/roles/k3s_upgrade/tasks/main.yml
@@ -36,6 +36,7 @@
       environment:
         INSTALL_K3S_SKIP_START: "true"
         INSTALL_K3S_VERSION: "{{ k3s_version }}"
+        INSTALL_K3S_SKIP_SELINUX_RPM: "{{ k3s_skip_selinux_rpm }}"
       changed_when: true
 
     - name: Restore K3s service


### PR DESCRIPTION
#### Changes ####

Add a variable `k3s_skip_selinux_rpm` that can be used to override/set INSTALL_K3S_SKIP_SELINUX_RPM.

#### Linked Issues ####