### PR TITLE
Add a handler to restart the K3s Server when the service file changes

### DIFF
--- a/roles/k3s_server/handlers/main.yml
+++ b/roles/k3s_server/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart K3s Server
+  ansible.builtin.systemd:
+    name: k3s
+    daemon_reload: true
+    state: restarted

--- a/roles/k3s_server/handlers/main.yml
+++ b/roles/k3s_server/handlers/main.yml
@@ -1,6 +1,0 @@
----
-- name: Restart K3s Server
-  ansible.builtin.systemd:
-    name: k3s
-    daemon_reload: true
-    state: restarted

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -65,6 +65,7 @@
         owner: root
         group: root
         mode: "0644"
+      notify: Restart K3s Server
 
     - name: Copy K3s service file [HA]
       when:
@@ -76,6 +77,7 @@
         owner: root
         group: root
         mode: "0644"
+      notify: Restart K3s Server
 
     - name: Add service environment variables
       when: extra_service_envs is defined
@@ -159,6 +161,7 @@
         owner: root
         group: root
         mode: "0644"
+      notify: Restart K3s Server
 
     - name: Copy K3s service file [External DB]
       when:
@@ -170,6 +173,7 @@
         owner: root
         group: root
         mode: "0644"
+      notify: Restart K3s Server
 
     - name: Enable and check K3s service
       ansible.builtin.systemd:

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -65,7 +65,7 @@
         owner: root
         group: root
         mode: "0644"
-      notify: Restart K3s Server
+      register: service_file_single
 
     - name: Copy K3s service file [HA]
       when:
@@ -77,7 +77,7 @@
         owner: root
         group: root
         mode: "0644"
-      notify: Restart K3s Server
+      register: service_file_ha
 
     - name: Add service environment variables
       when: extra_service_envs is defined
@@ -86,7 +86,18 @@
         line: "{{ item }}"
       with_items: "{{ extra_service_envs }}"
 
+    - name: Restart K3s service
+      when:
+        - ansible_facts.services['k3s.service'] is defined
+        - ansible_facts.services['k3s.service'].state == 'running'
+        - service_file_single.changed or service_file_ha.changed
+      ansible.builtin.systemd:
+        name: k3s
+        daemon_reload: true
+        state: restarted
+
     - name: Enable and check K3s service
+      when: ansible_facts.services['k3s.service'] is not defined or ansible_facts.services['k3s.service'].state != 'running'
       ansible.builtin.systemd:
         name: k3s
         daemon_reload: true
@@ -161,7 +172,7 @@
         owner: root
         group: root
         mode: "0644"
-      notify: Restart K3s Server
+      register: service_file_ha
 
     - name: Copy K3s service file [External DB]
       when:
@@ -173,9 +184,20 @@
         owner: root
         group: root
         mode: "0644"
-      notify: Restart K3s Server
+      register: service_file_external_db
+
+    - name: Restart K3s service
+      when:
+        - ansible_facts.services['k3s.service'] is defined
+        - ansible_facts.services['k3s.service'].state == 'running'
+        - service_file_ha.changed or service_file_external_db.changed
+      ansible.builtin.systemd:
+        name: k3s
+        daemon_reload: true
+        state: restarted
 
     - name: Enable and check K3s service
+      when: ansible_facts.services['k3s.service'] is not defined or ansible_facts.services['k3s.service'].state != 'running'
       ansible.builtin.systemd:
         name: k3s
         daemon_reload: true


### PR DESCRIPTION
#### Changes ####

Introduced a handler to restart the K3s service when a change to the `{{ systemd_dir }}/k3s.service` is detected.

I ran into the issue several times where I changed something in the template or `extra_server_args` and did not see my change reflected, and had to restart the service manually to see the change applied.
This PR solves that problem

#### Linked Issues ####
