### PR TITLE
Don't enable K3s service during airgap install

### DIFF
--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -113,7 +113,7 @@
       ansible.builtin.command:
         cmd: /usr/local/bin/k3s-install.sh
       environment:
-        INSTALL_K3S_SKIP_START: "true"
+        INSTALL_K3S_SKIP_ENABLE: "true"
         INSTALL_K3S_SKIP_DOWNLOAD: "true"
       changed_when: true
 
@@ -121,7 +121,7 @@
       ansible.builtin.command:
         cmd: /usr/local/bin/k3s-install.sh
       environment:
-        INSTALL_K3S_SKIP_START: "true"
+        INSTALL_K3S_SKIP_ENABLE: "true"
         INSTALL_K3S_SKIP_DOWNLOAD: "true"
         INSTALL_K3S_EXEC: "agent"
       changed_when: true


### PR DESCRIPTION
#### Changes ####
- Don't enable or start K3s during the airgap role. This fixes an issue where if an airgapped node was rebooted, the K3s server service would start up on agent nodes. Services are correctly enabled later in their respective `k3s_server` or `k3s_agent` roles.

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/342