### PR TITLE
Don't install `linux-modules-extra-raspi` on Ubuntu 24.04 and up

### DIFF
--- a/roles/raspberrypi/tasks/prereq/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/prereq/Ubuntu.yml
@@ -15,4 +15,4 @@
     name: linux-modules-extra-raspi
     update_cache: true
     state: present
-  when: "ansible_distribution_version is version('20.10', '>=')"
+  when: "ansible_distribution_version is version('20.10', '>=') and ansible_distribution_version is version('24.04', '<')"


### PR DESCRIPTION
The extra modules were merged into the normal modules packet as of Kernel 6.8/Ubuntu 24.04, for reference see:

* Discussion on Launchpad mentioning the merge: [Link](https://answers.launchpad.net/ubuntu/+source/linux-raspi/+question/817506)
* Bug Tracker mentioning the `extra` package removal: [Link](https://bugs.launchpad.net/ubuntu/+source/linux-raspi/+bug/2048862)
* The Ubuntu Kernel release cycle showing the link between kernel version and distro version: [Link](https://ubuntu.com/about/release-cycle#ubuntu-kernel-release-cycle)

Successfully tested on my small 2 node cluster setup.

#### Changes ####

Package `linux-modules-extra-raspi` is not installed on Raspberry Pi when running Ubuntu 24.04 and up.

#### Linked Issues ####

N/A