### PR TITLE
Make k3s_server role idempotent

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -104,8 +104,20 @@
       become: false
       changed_when: false
 
+    # Copy the k3s config to a second file to detect changes.
+    # If no changes are found, we can skip copying the kubeconfig to the control node.
+    - name: Copy k3s.yaml to second file
+      ansible.builtin.copy:
+        src: /etc/rancher/k3s/k3s.yaml
+        dest: /etc/rancher/k3s/k3s-copy.yaml
+        mode: "0600"
+        remote_src: true
+      register: copy_k3s_yaml_file
+
     - name: Apply K3S kubeconfig to control node
-      when: kubectl_installed.rc == 0
+      when:
+        - kubectl_installed.rc == 0
+        - copy_k3s_yaml_file.changed
       block:
         - name: Copy kubeconfig to control node
           ansible.builtin.fetch:


### PR DESCRIPTION

#### Changes ####
Introduce copy of k3s.yaml file to detect changes and skip control node changes.
It's a bit of a workaround, but I consider it a pragmatic solution to prevent Ansible from always reporting 4 changes, the `k3s.yaml` file is different from the `~/.kube/config.new` file due to the changes the next 3 tasks make to it.

**Before**
<img width="816" alt="Screenshot 2024-07-13 at 15 34 03" src="https://github.com/user-attachments/assets/fbf78a6f-2c00-4a95-aee6-a42335b4904b">


**After**
<img width="815" alt="Screenshot 2024-07-13 at 15 34 14" src="https://github.com/user-attachments/assets/8a859850-a861-45a7-9767-db32ce6f7ed1">

(192.168.64.9 is the first server)


#### Linked Issues ####