### PR TITLE
Fix kubeconfig merge with existing config

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -148,7 +148,7 @@
             - csa_result.rc == 0
 
         - name: Setup kubeconfig context on control node - {{ cluster_context }}
-          when: kubeconfig != "~/.kube/config"
+          when: kubeconfig == "~/.kube/config.new"
           ansible.builtin.replace:
             path: "{{ kubeconfig }}"
             regexp: 'default'

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -151,8 +151,8 @@
           when: kubeconfig != "~/.kube/config"
           ansible.builtin.replace:
             path: "{{ kubeconfig }}"
-            regexp: 'name: default'
-            replace: 'name: {{ cluster_context }}'
+            regexp: 'default'
+            replace: '{{ cluster_context }}'
           delegate_to: 127.0.0.1
           become: false
 
@@ -160,8 +160,8 @@
           when: kubeconfig != "~/.kube/config"
           ansible.builtin.shell: |
             TFILE=$(mktemp)
-            KUBECONFIG={{ kubeconfig }} kubectl config set-context {{ cluster_context }} --user={{ cluster_context }} --cluster={{ cluster_context }}
-            KUBECONFIG={{ kubeconfig }} kubectl config view --flatten > ${TFILE}
+            KUBECONFIG={{ kubeconfig }}:~/.kube/config kubectl config set-context {{ cluster_context }} --user={{ cluster_context }} --cluster={{ cluster_context }}
+            KUBECONFIG={{ kubeconfig }}:~/.kube/config kubectl config view --flatten > ${TFILE}
             mv ${TFILE} {{ kubeconfig }}
           delegate_to: 127.0.0.1
           become: false

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -157,12 +157,12 @@
           become: false
 
         - name: Merge with any existing kubeconfig on control node
-          when: kubeconfig != "~/.kube/config"
+          when: kubeconfig == "~/.kube/config.new"
           ansible.builtin.shell: |
             TFILE=$(mktemp)
             KUBECONFIG={{ kubeconfig }}:~/.kube/config kubectl config set-context {{ cluster_context }} --user={{ cluster_context }} --cluster={{ cluster_context }}
             KUBECONFIG={{ kubeconfig }}:~/.kube/config kubectl config view --flatten > ${TFILE}
-            mv ${TFILE} {{ kubeconfig }}
+            mv ${TFILE} ~/.kube/config
           delegate_to: 127.0.0.1
           become: false
           register: mv_result


### PR DESCRIPTION
#### Changes ####
Since the existing config file was not in scope, the commands did not perform anything.

To fix it, I include the existing kubeconfig path in KUBECONFIG variable such that the YAML contents are merged when it prints out via `kubectl config view --flatten`

Also, replacing keyword "default" with ansible variable `kube_config` can also help replace the `current-context` in the kubeconfig file.

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/350