### PR TITLE
More flexible cgroup settings

### DIFF
--- a/roles/raspberrypi/tasks/prereq/Archlinux.yml
+++ b/roles/raspberrypi/tasks/prereq/Archlinux.yml
@@ -1,8 +1,13 @@
 ---
 - name: Enable cgroup via boot commandline if not already enabled
-  ansible.builtin.lineinfile:
+  ansible.builtin.replace:
     path: /boot/boot.txt
-    regexp: '^(setenv bootargs console=ttyS1,115200 console=tty0 root=PARTUUID=\${uuid} rw rootwait smsc95xx.macaddr="\${usbethaddr}")'
-    line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
-    backrefs: true
+    regexp: '^(setenv bootargs console=ttyS1,115200 console=tty0 root=PARTUUID=\${uuid} rw rootwait smsc95xx.macaddr="\${usbethaddr}"(?!.*\b{{ cgroup_item }}\b).*)$'
+    replace: '\1 {{ cgroup_item }}'
+  with_items:
+    - "cgroup_enable=cpuset"
+    - "cgroup_memory=1"
+    - "cgroup_enable=memory"
+  loop_control:
+    loop_var: cgroup_item
   notify: Regenerate bootloader image

--- a/roles/raspberrypi/tasks/prereq/CentOS.yml
+++ b/roles/raspberrypi/tasks/prereq/CentOS.yml
@@ -2,7 +2,12 @@
 - name: Enable cgroup via boot commandline if not already enabled
   ansible.builtin.lineinfile:
     path: /boot/cmdline.txt
-    backrefs: true
-    regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
-    line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
+    regexp: '^([\w](?!.*\b{{ cgroup_item }}\b).*)$'
+    replace: '\1 {{ cgroup_item }}'
+  with_items:
+    - "cgroup_enable=cpuset"
+    - "cgroup_memory=1"
+    - "cgroup_enable=memory"
+  loop_control:
+    loop_var: cgroup_item
   notify: Reboot Pi

--- a/roles/raspberrypi/tasks/prereq/CentOS.yml
+++ b/roles/raspberrypi/tasks/prereq/CentOS.yml
@@ -1,6 +1,6 @@
 ---
 - name: Enable cgroup via boot commandline if not already enabled
-  ansible.builtin.lineinfile:
+  ansible.builtin.replace:
     path: /boot/cmdline.txt
     regexp: '^([\w](?!.*\b{{ cgroup_item }}\b).*)$'
     replace: '\1 {{ cgroup_item }}'

--- a/roles/raspberrypi/tasks/prereq/Debian.yml
+++ b/roles/raspberrypi/tasks/prereq/Debian.yml
@@ -5,11 +5,16 @@
   register: boot_firmware_cmdline_txt
 
 - name: Enable cgroup via boot commandline if not already enabled
-  ansible.builtin.lineinfile:
+  ansible.builtin.replace:
     path: "{{ (boot_firmware_cmdline_txt.stat.exists) | ternary('/boot/firmware/cmdline.txt', '/boot/cmdline.txt') }}"
-    backrefs: true
-    regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
-    line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
+    regexp: '^([\w](?!.*\b{{ cgroup_item }}\b).*)$'
+    replace: '\1 {{ cgroup_item }}'
+  with_items:
+    - "cgroup_enable=cpuset"
+    - "cgroup_memory=1"
+    - "cgroup_enable=memory"
+  loop_control:
+    loop_var: cgroup_item
   notify: Reboot Pi
 
 - name: Gather the package facts

--- a/roles/raspberrypi/tasks/prereq/Raspbian.yml
+++ b/roles/raspberrypi/tasks/prereq/Raspbian.yml
@@ -2,9 +2,14 @@
 - name: Enable cgroup via boot commandline if not already enabled
   ansible.builtin.lineinfile:
     path: /boot/cmdline.txt
-    backrefs: true
-    regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
-    line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
+    regexp: '^([\w](?!.*\b{{ cgroup_item }}\b).*)$'
+    replace: '\1 {{ cgroup_item }}'
+  with_items:
+    - "cgroup_enable=cpuset"
+    - "cgroup_memory=1"
+    - "cgroup_enable=memory"
+  loop_control:
+    loop_var: cgroup_item
   notify: Reboot Pi
 
 - name: Gather the package facts

--- a/roles/raspberrypi/tasks/prereq/Raspbian.yml
+++ b/roles/raspberrypi/tasks/prereq/Raspbian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Enable cgroup via boot commandline if not already enabled
-  ansible.builtin.lineinfile:
+  ansible.builtin.replace:
     path: /boot/cmdline.txt
     regexp: '^([\w](?!.*\b{{ cgroup_item }}\b).*)$'
     replace: '\1 {{ cgroup_item }}'

--- a/roles/raspberrypi/tasks/prereq/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/prereq/Ubuntu.yml
@@ -1,7 +1,7 @@
 ---
 - name: Enable cgroup via boot commandline if not already enabled
   when: lookup('fileglob', '/boot/firmware/cmdline.txt', errors='warn') | length > 0
-  ansible.builtin.lineinfile:
+  ansible.builtin.replace:
     path: /boot/firmware/cmdline.txt
     regexp: '^([\w](?!.*\b{{ cgroup_item }}\b).*)$'
     replace: '\1 {{ cgroup_item }}'

--- a/roles/raspberrypi/tasks/prereq/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/prereq/Ubuntu.yml
@@ -3,9 +3,14 @@
   when: lookup('fileglob', '/boot/firmware/cmdline.txt', errors='warn') | length > 0
   ansible.builtin.lineinfile:
     path: /boot/firmware/cmdline.txt
-    backrefs: true
-    regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
-    line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
+    regexp: '^([\w](?!.*\b{{ cgroup_item }}\b).*)$'
+    replace: '\1 {{ cgroup_item }}'
+  with_items:
+    - "cgroup_enable=cpuset"
+    - "cgroup_memory=1"
+    - "cgroup_enable=memory"
+  loop_control:
+    loop_var: cgroup_item
   notify: Reboot Pi
 
 - name: Install Ubuntu Raspi Extra Packages


### PR DESCRIPTION
Currently the the relevant tasks match the kernel command line to three cgroup related parameters in the hard-coded order. I already had two of them and when I ran the playbook I ended up with two of them being repeated. A cleaner way to apply it is to match one parameter at the time and add it if missing.

I tested only Debian version, but the other are a simple copy and paste except for Archlinux.