### PR TITLE
Better cleanup with reset playbook

### DIFF
--- a/playbooks/reset.yml
+++ b/playbooks/reset.yml
@@ -31,3 +31,13 @@
       ansible.builtin.file:
         path: /etc/rancher/k3s/config.yaml
         state: absent
+
+- name: Undo user setup
+  hosts: server
+  tasks:
+  - name: Remove K3s commands from ~/.bashrc
+    ansible.builtin.lineinfile:
+      path: "~{{ ansible_user }}/.bashrc"
+      search_string: "Added by k3s-ansible"
+      state: absent
+


### PR DESCRIPTION
The install playbook adds some convenience commands into the user's .bashrc. If K3s is uninstalled, these commands produce errors. Since they are eaily identifiable, it is trivial to remove them to improve the user's experience.

#### Changes ####

#### Linked Issues ####