### PR TITLE
Security exposure related to the token

### DIFF
--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -35,14 +35,13 @@
         INSTALL_K3S_EXEC: "agent"
       changed_when: true
 
-    - name: Add the token and first server URL for joining the cluster to the environment
+    - name: Add the token for joining the cluster to the environment
       no_log: true # avoid logging the server token
       ansible.builtin.lineinfile:
         path: "{{ systemd_dir }}/k3s-agent.service.env"
         line: "{{ item }}"
       with_items:
         - "K3S_TOKEN={{ token }}"
-        - "K3S_URL=https://{{ api_endpoint }}:{{ api_port }}"
 
 - name: Copy K3s service file
   register: k3s_agent_service

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -35,6 +35,15 @@
         INSTALL_K3S_EXEC: "agent"
       changed_when: true
 
+    - name: Add the token and first server URL for joining the cluster to the environment
+      no_log: true # avoid logging the server token
+      ansible.builtin.lineinfile:
+        path: "{{ systemd_dir }}/k3s-agent.service.env"
+        line: "{{ item }}"
+      with_items:
+        - "K3S_TOKEN={{ token }}"
+        - "K3S_URL=https://{{ api_endpoint }}:{{ api_port }}"
+
 - name: Copy K3s service file
   register: k3s_agent_service
   ansible.builtin.template:

--- a/roles/k3s_agent/templates/k3s-agent.service.j2
+++ b/roles/k3s_agent/templates/k3s-agent.service.j2
@@ -26,4 +26,4 @@ RestartSec=5s
 ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service'
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s agent --data-dir {{ k3s_server_location }} {{ extra_agent_args }}
+ExecStart=/usr/local/bin/k3s agent --data-dir {{ k3s_server_location }} --server https://{{ api_endpoint }}:{{ api_port }} {{ extra_agent_args }}

--- a/roles/k3s_agent/templates/k3s-agent.service.j2
+++ b/roles/k3s_agent/templates/k3s-agent.service.j2
@@ -26,4 +26,4 @@ RestartSec=5s
 ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service'
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s agent --data-dir {{ k3s_server_location }} --server https://{{ api_endpoint }}:{{ api_port }} --token {{ token }} {{ extra_agent_args }}
+ExecStart=/usr/local/bin/k3s agent --data-dir {{ k3s_server_location }} {{ extra_agent_args }}

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -181,14 +181,13 @@
     - (groups[server_group] | length) > 1
     - inventory_hostname != groups[server_group][0]
   block:
-    - name: Add the token and first server URL for joining the cluster to the environment
+    - name: Add the token for joining the cluster to the environment
       no_log: true # avoid logging the server token
       ansible.builtin.lineinfile:
         path: "{{ systemd_dir }}/k3s.service.env"
         line: "{{ item }}"
       with_items:
         - "K3S_TOKEN={{ token }}"
-        - "K3S_URL=https://{{ api_endpoint }}:{{ api_port }}"
 
     - name: Copy K3s service file [HA]
       when: not use_external_database

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -86,6 +86,13 @@
         line: "{{ item }}"
       with_items: "{{ extra_service_envs }}"
 
+    # Add the token to the environment.
+    - name: Add token as an environment variable
+      no_log: true # avoid logging the server token
+      ansible.builtin.lineinfile:
+        path: "{{ systemd_dir }}/k3s.service.env"
+        line: "K3S_TOKEN={{ token }}"
+
     - name: Restart K3s service
       when:
         - ansible_facts.services['k3s.service'] is defined
@@ -174,6 +181,15 @@
     - (groups[server_group] | length) > 1
     - inventory_hostname != groups[server_group][0]
   block:
+    - name: Add the token and first server URL for joining the cluster to the environment
+      no_log: true # avoid logging the server token
+      ansible.builtin.lineinfile:
+        path: "{{ systemd_dir }}/k3s.service.env"
+        line: "{{ item }}"
+      with_items:
+        - "K3S_TOKEN={{ token }}"
+        - "K3S_URL=https://{{ api_endpoint }}:{{ api_port }}"
+
     - name: Copy K3s service file [HA]
       when: not use_external_database
       ansible.builtin.template:

--- a/roles/k3s_server/templates/k3s-cluster-init.service.j2
+++ b/roles/k3s_server/templates/k3s-cluster-init.service.j2
@@ -25,4 +25,4 @@ Restart=always
 RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s server --cluster-init --data-dir {{ k3s_server_location }} --token {{ token }} {{ extra_server_args }} 
+ExecStart=/usr/local/bin/k3s server --cluster-init --data-dir {{ k3s_server_location }} {{ extra_server_args }} 

--- a/roles/k3s_server/templates/k3s-ha.service.j2
+++ b/roles/k3s_server/templates/k3s-ha.service.j2
@@ -25,4 +25,4 @@ Restart=always
 RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s server --data-dir {{ k3s_server_location }} {{ extra_server_args }} 
+ExecStart=/usr/local/bin/k3s server --data-dir {{ k3s_server_location }} --server https://{{ api_endpoint }}:{{ api_port }} {{ extra_server_args }} 

--- a/roles/k3s_server/templates/k3s-ha.service.j2
+++ b/roles/k3s_server/templates/k3s-ha.service.j2
@@ -25,4 +25,4 @@ Restart=always
 RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s server --data-dir {{ k3s_server_location }} --server https://{{ api_endpoint }}:{{ api_port }} --token {{ token }} {{ extra_server_args }} 
+ExecStart=/usr/local/bin/k3s server --data-dir {{ k3s_server_location }} {{ extra_server_args }} 

--- a/roles/k3s_server/templates/k3s-single.service.j2
+++ b/roles/k3s_server/templates/k3s-single.service.j2
@@ -25,4 +25,4 @@ Restart=always
 RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s server --data-dir {{ k3s_server_location }} --token {{ token }} {{ extra_server_args }} 
+ExecStart=/usr/local/bin/k3s server --data-dir {{ k3s_server_location }} {{ extra_server_args }} 


### PR DESCRIPTION
The installation playbook saves the token into the systemd unit configuration file /etc/systemd/system/k3s.service. The problem is that according to K3s' documentation "the server token should be guarded carefully" (https://docs.k3s.io/cli/token), yet the configuration file is readable by anybody. A better solution is to save the token into its corresponding environment file /etc/systemd/system/k3s.service.env which is readable by the super user only. This is what the standard K3s' installation script (https://get.k3s.io) does.

#### Changes ####

#### Linked Issues ####