### PR TITLE
Add token to agents on existing clusters

### DIFF
--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -35,13 +35,13 @@
         INSTALL_K3S_EXEC: "agent"
       changed_when: true
 
-    - name: Add the token for joining the cluster to the environment
-      no_log: true # avoid logging the server token
-      ansible.builtin.lineinfile:
-        path: "{{ systemd_dir }}/k3s-agent.service.env"
-        line: "{{ item }}"
-      with_items:
-        - "K3S_TOKEN={{ token }}"
+- name: Add the token for joining the cluster to the environment
+  no_log: true # avoid logging the server token
+  ansible.builtin.lineinfile:
+    path: "{{ systemd_dir }}/k3s-agent.service.env"
+    line: "{{ item }}"
+  with_items:
+    - "K3S_TOKEN={{ token }}"
 
 - name: Copy K3s service file
   register: k3s_agent_service


### PR DESCRIPTION
#### Changes ####
#356 introduced a subtle issue for existing clusters where the token is removed from the service unit but not added to the `.env` file unless a version update happens at the same time. By moving the task `Add the token for joining the cluster to the environment` outside of the `block:` it makes sure it is executed in all cases (a very subtle spacing issue).

Issue occurring: https://github.com/nycmeshnet/k8s-infra/actions/runs/10756493721/job/29829415464#step:14:569
Testing fix: https://github.com/nycmeshnet/k8s-infra/actions/runs/10805984455/job/29973976530#step:14:570 - I confirmed the value is now in the `.env` file and our nodes remained active.

Thank you for maintaining k3s-ansible, it is nice and easy to use. Also, #356 is good for security, thank you for this.