### PR TITLE
Handle both new and old cmdline.txt locations in Raspbian/Raspberry Pi OS

### DIFF
--- a/roles/raspberrypi/tasks/prereq/Raspbian.yml
+++ b/roles/raspberrypi/tasks/prereq/Raspbian.yml
@@ -1,7 +1,12 @@
 ---
+- name: Check if /boot/firmware/cmdline.txt exists
+  ansible.builtin.stat:
+    path: /boot/firmware/cmdline.txt
+  register: boot_firmware_cmdline_txt
+
 - name: Enable cgroup via boot commandline if not already enabled
   ansible.builtin.replace:
-    path: /boot/cmdline.txt
+    path: "{{ (boot_firmware_cmdline_txt.stat.exists) | ternary('/boot/firmware/cmdline.txt', '/boot/cmdline.txt') }}"
     regexp: '^([\w](?!.*\b{{ cgroup_item }}\b).*)$'
     replace: '\1 {{ cgroup_item }}'
   with_items:


### PR DESCRIPTION
#### Changes ####
- Handle the existence of both `/boot/firmware/cmdline.txt` or `/boot/cmdline.txt` in Raspbian
#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/358