### PR TITLE
Don't require a bogus k3s_version for airgap installs

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -15,7 +15,7 @@
 #   - we couldn't get k3s installed version in the first task of this role
 #   - the installed version of K3s on the nodes is older than the requested version in ansible vars
 - name: Download artifact only if needed
-  when: k3s_version_output.rc != 0 or installed_k3s_version is version(k3s_version, '<') and airgap_dir is undefined
+  when: airgap_dir is undefined and ( k3s_version_output.rc != 0 or installed_k3s_version is version(k3s_version, '<') )
   block:
     - name: Download K3s install script
       ansible.builtin.get_url:


### PR DESCRIPTION
#### Changes ####
- Better handle airgap_dir option. Correctly shortcut the `when` check if airgap_dir is defined, removing the need to specify a `k3s_version` for airgaps (the version is whatever version of the K3s binary you downloaded and are distributing)
#### Linked Issues ####