### PR TITLE
Prevent multiple tokens in k3s.service.env

### DIFF
--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -35,11 +35,11 @@
         INSTALL_K3S_EXEC: "agent"
       changed_when: true
 
-- name: Delete any existing token from the environment
+- name: Delete any existing token from the environment if different from the new one
   ansible.builtin.lineinfile:
     state: absent
     path: "{{ systemd_dir }}/k3s-agent.service.env"
-    search_string: "K3S_TOKEN="
+    regexp: "^K3S_TOKEN=\\s*(?!{{ token }}\\s*$)"
 
 - name: Add the token for joining the cluster to the environment
   no_log: true # avoid logging the server token

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -35,6 +35,12 @@
         INSTALL_K3S_EXEC: "agent"
       changed_when: true
 
+- name: Delete any existing token from the environment
+  ansible.builtin.lineinfile:
+    state: absent
+    path: "{{ systemd_dir }}/k3s-agent.service.env"
+    search_string: "K3S_TOKEN="
+
 - name: Add the token for joining the cluster to the environment
   no_log: true # avoid logging the server token
   ansible.builtin.lineinfile:

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -86,6 +86,12 @@
         line: "{{ item }}"
       with_items: "{{ extra_service_envs }}"
 
+    - name: Delete any existing token from the environment
+      ansible.builtin.lineinfile:
+        state: absent
+        path: "{{ systemd_dir }}/k3s.service.env"
+        search_string: "K3S_TOKEN="
+
     # Add the token to the environment.
     - name: Add token as an environment variable
       no_log: true # avoid logging the server token
@@ -181,6 +187,12 @@
     - (groups[server_group] | length) > 1
     - inventory_hostname != groups[server_group][0]
   block:
+    - name: Delete any existing token from the environment
+      ansible.builtin.lineinfile:
+        state: absent
+        path: "{{ systemd_dir }}/k3s.service.env"
+        search_string: "K3S_TOKEN="
+
     - name: Add the token for joining the cluster to the environment
       no_log: true # avoid logging the server token
       ansible.builtin.lineinfile:

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -86,11 +86,11 @@
         line: "{{ item }}"
       with_items: "{{ extra_service_envs }}"
 
-    - name: Delete any existing token from the environment
+    - name: Delete any existing token from the environment if different from the new one
       ansible.builtin.lineinfile:
         state: absent
         path: "{{ systemd_dir }}/k3s.service.env"
-        search_string: "K3S_TOKEN="
+        regexp: "^K3S_TOKEN=\\s*(?!{{ token }}\\s*$)"
 
     # Add the token to the environment.
     - name: Add token as an environment variable
@@ -187,11 +187,11 @@
     - (groups[server_group] | length) > 1
     - inventory_hostname != groups[server_group][0]
   block:
-    - name: Delete any existing token from the environment
+    - name: Delete any existing token from the environment if different from the new one
       ansible.builtin.lineinfile:
         state: absent
         path: "{{ systemd_dir }}/k3s.service.env"
-        search_string: "K3S_TOKEN="
+        regexp: "^K3S_TOKEN=\\s*(?!{{ token }}\\s*$)"
 
     - name: Add the token for joining the cluster to the environment
       no_log: true # avoid logging the server token


### PR DESCRIPTION
If site.yml playbook is executed multiple times with different tokens, they will all accumulate in k3s.service.env. They won't do any harm because the last one wins, however it is a matter of good housekeeping to delete the old before inserting a new one.

#### Changes ####

#### Linked Issues ####