### PR TITLE
Handle multiple architectures when distributing airgap binary

### DIFF
--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -28,7 +28,7 @@
     - name: Determine architecture and set k3s_arch
       set_fact:
         k3s_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'arm' if ansible_architecture == 'armv7l' else 'amd64' }}"
-    
+
     - name: Distribute K3s binary {{ k3s_arch }}
       ansible.builtin.copy:
         src: "{{ item }}"

--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -26,7 +26,7 @@
         mode: "0755"
 
     - name: Determine architecture and set k3s_arch
-      set_fact:
+      ansible.builtin.set_fact:
         k3s_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'arm' if ansible_architecture == 'armv7l' else 'amd64' }}"
 
     - name: Distribute K3s binary {{ k3s_arch }}

--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -25,13 +25,21 @@
         group: root
         mode: "0755"
 
-    - name: Distribute K3s binary
+    - name: Determine architecture and set k3s_arch
+      set_fact:
+        k3s_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'arm' if ansible_architecture == 'armv7l' else 'amd64' }}"
+    
+    - name: Distribute K3s binary {{ k3s_arch }}
       ansible.builtin.copy:
-        src: "{{ airgap_dir }}/k3s"
+        src: "{{ item }}"
         dest: /usr/local/bin/k3s
         owner: root
         group: root
         mode: "0755"
+      with_first_found:
+        - files:
+            - "{{ airgap_dir }}/k3s-{{ k3s_arch }}"
+            - "{{ airgap_dir }}/k3s"
 
     - name: Distribute K3s SELinux RPM
       ansible.builtin.copy:
@@ -60,12 +68,7 @@
         mode: "0755"
         state: directory
 
-    - name: Determine Architecture
-      ansible.builtin.set_fact:
-        k3s_arch: "{{ ansible_architecture }}"
-
-    - name: Distribute K3s amd64 images
-      when: ansible_architecture == 'x86_64'
+    - name: Distribute K3s images {{ k3s_arch }}
       ansible.builtin.copy:
         src: "{{ item }}"
         dest: /var/lib/rancher/k3s/agent/images/{{ item | basename }}
@@ -74,40 +77,9 @@
         mode: "0755"
       with_first_found:
         - files:
-            - "{{ airgap_dir }}/k3s-airgap-images-amd64.tar.zst"
-            - "{{ airgap_dir }}/k3s-airgap-images-amd64.tar.gz"
-            - "{{ airgap_dir }}/k3s-airgap-images-amd64.tar"
-          skip: true
-
-    - name: Distribute K3s arm64 images
-      when: ansible_architecture == 'aarch64'
-      ansible.builtin.copy:
-        src: "{{ item }}"
-        dest: /var/lib/rancher/k3s/agent/images/{{ item | basename }}
-        owner: root
-        group: root
-        mode: "0755"
-      with_first_found:
-        - files:
-            - "{{ airgap_dir }}/k3s-airgap-images-arm64.tar.zst"
-            - "{{ airgap_dir }}/k3s-airgap-images-arm64.tar.gz"
-            - "{{ airgap_dir }}/k3s-airgap-images-arm64.tar"
-          skip: true
-
-    - name: Distribute K3s arm images
-      when: ansible_architecture == 'armv7l'
-      ansible.builtin.copy:
-        src: "{{ item }}"
-        dest: /var/lib/rancher/k3s/agent/images/{{ item | basename }}
-        owner: root
-        group: root
-        mode: "0755"
-      with_first_found:
-        - files:
-            - "{{ airgap_dir }}/k3s-airgap-images-arm.tar.zst"
-            - "{{ airgap_dir }}/k3s-airgap-images-arm.tar.gz"
-            - "{{ airgap_dir }}/k3s-airgap-images-arm.tar"
-          skip: true
+            - "{{ airgap_dir }}/k3s-airgap-images-{{ k3s_arch }}.tar.zst"
+            - "{{ airgap_dir }}/k3s-airgap-images-{{ k3s_arch }}.tar.gz"
+            - "{{ airgap_dir }}/k3s-airgap-images-{{ k3s_arch }}.tar"
 
     - name: Run K3s Install [server]
       ansible.builtin.command:


### PR DESCRIPTION
#### Changes ####
- Match architecture to what K3s release artifacts suffixes are.
- Handle arm/arm64 naming for the k3s binary artifacts.
Note: This potentially allows for multiarch airgap clusters, if you download the appropriate artifacts for all relevant architectures, but I didn't explicitly test this. Your airgap folder would look something like 
  ```
  ls -la ./playbooks/my-airgap/
  -rw-r--r-- 1 derek derek  68337816 Oct  7 11:24 k3s
  -rw-r--r-- 1 derek derek 175681141 Oct  7 11:24 k3s-airgap-images-amd64.tar.gz
  -rw-r--r-- 1 derek derek 132759685 Oct  7 11:04 k3s-airgap-images-arm64.tar.zst
  -rw-r--r-- 1 derek derek  63504536 Oct  7 11:04 k3s-arm64
  ```
#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/365