### PR TITLE
Don't modify existing airgap k3s-install script 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 # ENV['VAGRANT_NO_PARALLEL'] = 'no'
 NODE_ROLES = ["server-0", "server-1", "server-2", "agent-0", "agent-1"]
-NODE_BOXES = ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004']
+NODE_BOXES = ['bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04']
 NODE_CPUS = 2
 NODE_MEMORY = 2048
 # Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks 
@@ -26,12 +26,14 @@ def provision(vm, role, node_num)
       "k3s_cluster:children" => ["server", "agent"],
     }
     ansible.extra_vars = {
-      k3s_version: "v1.26.9+k3s1",
+      k3s_version: "v1.28.14+k3s1",
       api_endpoint: "#{NETWORK_PREFIX}.100",
       token: "myvagrant",
       # Required to use the private network configured above
       extra_server_args: "--node-external-ip #{node_ip} --flannel-iface eth1", 
       extra_agent_args: "--node-external-ip #{node_ip} --flannel-iface eth1",
+      # Airgap setup, left as reference
+      # airgap_dir: "./my_airgap",
       # Optional, left as reference for ruby-ansible syntax
       # extra_service_envs: [ "NO_PROXY='localhost'" ],
       # server_config_yaml: <<~YAML

--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -8,9 +8,18 @@
         that: "ansible_version.full is version_compare('2.12', '>=')"
         msg: "The Airgap role requires at least ansible-core 2.12"
 
+    - name: Check for existing install script
+      become: false
+      delegate_to: localhost
+      ansible.builtin.stat:
+        path: "{{ airgap_dir + '/k3s-install.sh' }}"
+      register: host_install_script
+
     - name: Download k3s install script
       become: false
       delegate_to: localhost
+      # Workaround for https://github.com/ansible/ansible/issues/64016
+      when: not host_install_script.stat.exists
       ansible.builtin.get_url:
         url: https://get.k3s.io/
         timeout: 120


### PR DESCRIPTION
#### Changes ####
- Bump vagrant OS (generic no longer publishes vagrant boxes)
- If a k3s-install.sh script already exists in the airgap dir on the host, either because the user already downloaded it manually, or from a previous airgap deploy, don't overwrite it. 

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/371