### PR TITLE
Fix order of operations when install agent airgap

### DIFF
--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -15,7 +15,7 @@
 #   - we couldn't get k3s installed version in the first task of this role
 #   - the installed version of K3s on the nodes is older than the requested version in ansible vars
 - name: Download artifact only if needed
-  when: k3s_version_output.rc != 0 or installed_k3s_version is version(k3s_version, '<') and airgap_dir is undefined
+  when: airgap_dir is undefined and ( k3s_version_output.rc != 0 or installed_k3s_version is version(k3s_version, '<') )
   block:
     - name: Download K3s install script
       ansible.builtin.get_url:


### PR DESCRIPTION
#### Changes ####
Fixed a order of operations error for agent airgap installs. Previously fixed for servers in https://github.com/k3s-io/k3s-ansible/commit/19f99f71ed3f406e6a8681712b4308c542156575
#### Linked Issues ####