### PR TITLE
Remove irrelevant kubectl symlink

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -254,13 +254,6 @@
   when: user_kubectl
   block:
 
-    - name: Create kubectl symlink
-      when: lookup('fileglob', '/usr/local/bin/kubectl', errors='warn') | length == 0
-      ansible.builtin.file:
-        src: /usr/local/bin/k3s
-        dest: /usr/local/bin/kubectl
-        state: link
-
     - name: Create directory .kube
       ansible.builtin.file:
         path: ~{{ ansible_user }}/.kube


### PR DESCRIPTION
#### Changes ####
K3s install script already handles this with https://github.com/k3s-io/k3s/blob/master/install.sh#L747 and handles the case around where K3s binary is installed. 

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/374