### PR TITLE
Fixing k3s uninstallation failures when k3s is installed via airgap role

### DIFF
--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -97,6 +97,7 @@
           skip: true
 
     - name: Run K3s Install [server]
+      when: inventory_hostname in groups['server']
       ansible.builtin.command:
         cmd: /usr/local/bin/k3s-install.sh
       environment:
@@ -105,6 +106,7 @@
       changed_when: true
 
     - name: Run K3s Install [agent]
+      when: inventory_hostname in groups['agent']
       ansible.builtin.command:
         cmd: /usr/local/bin/k3s-install.sh
       environment:


### PR DESCRIPTION
#### Changes ####
These changes will make sure:
- `k3s.service` is only installed for server group.
- `k3s-agent.service` is only installed for agent group.

As we will only have the expected service installed on the node, `k3s-uninstall.sh` script will seamlessly clean up the cluster during teardown.

#### Linked Issues ####
#383 