### PR TITLE
Make sure we create token environment file if it does not exist already

### DIFF
--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -50,6 +50,7 @@
   ansible.builtin.lineinfile:
     path: "{{ systemd_dir }}/k3s-agent.service.env"
     line: "{{ item }}"
+    create: yes
   with_items:
     - "K3S_TOKEN={{ token }}"
 

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -99,6 +99,7 @@
       ansible.builtin.lineinfile:
         path: "{{ systemd_dir }}/k3s.service.env"
         line: "K3S_TOKEN={{ token }}"
+        create: yes
       when: token is defined
 
     - name: Restart K3s service
@@ -220,6 +221,7 @@
       ansible.builtin.lineinfile:
         path: "{{ systemd_dir }}/k3s.service.env"
         line: "{{ item }}"
+        create: yes
       with_items:
         - "K3S_TOKEN={{ token }}"
 


### PR DESCRIPTION
As it currently stands, when the `lineinfile` tasks run in either agent or server roles it fails if the file does not exist.  I have added the create option set to true:
```yaml
create: yes
```

You can check the [Ansible documentation](https://docs.ansible.com/ansible/2.9/modules/lineinfile_module.html#parameter-create)