### PR TITLE
Escape regex special characters in token value

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -91,7 +91,7 @@
       ansible.builtin.lineinfile:
         state: absent
         path: "{{ systemd_dir }}/k3s.service.env"
-        regexp: "^K3S_TOKEN=\\s*(?!{{ token | default('') }}\\s*$)"
+        regexp: "^K3S_TOKEN=\\s*(?!{{ token | default('') | regex_escape }}\\s*$)"
 
     # Add the token to the environment if it has been provided.
     # Otherwise, let the first server create one on the first run.


### PR DESCRIPTION
#### Changes ####
- use `regex_escape` to handle `*` and `+` characters in the k3s token

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/389