### PR TITLE
Only apply K3s autocomplete when ansible_user is defined

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -35,6 +35,7 @@
       changed_when: true
 
 - name: Add K3s autocomplete to user bashrc
+  when: ansible_user is defined
   ansible.builtin.lineinfile:
     path: "~{{ ansible_user }}/.bashrc"
     regexp: '\.\s+<\(k3s completion bash\)'


### PR DESCRIPTION
#### Changes ####
Only apply bash autocomplete when the ansible_user is defined.

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/396