### PR TITLE
fix: make the roles work even when hosts are aliased in the inventory

### DIFF
--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -97,7 +97,7 @@
           skip: true
 
     - name: Run K3s Install [server]
-      when: inventory_hostname in groups['server']
+      when: inventory_hostname in groups['server'] or ansible_host in groups['server']
       ansible.builtin.command:
         cmd: /usr/local/bin/k3s-install.sh
       environment:
@@ -106,7 +106,7 @@
       changed_when: true
 
     - name: Run K3s Install [agent]
-      when: inventory_hostname in groups['agent']
+      when: inventory_hostname in groups['agent'] or ansible_host in groups['agent']
       ansible.builtin.command:
         cmd: /usr/local/bin/k3s-install.sh
       environment:

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -56,7 +56,7 @@
       register: _server_config_result
 
 - name: Init first server node
-  when: inventory_hostname == groups[server_group][0]
+  when: inventory_hostname == groups[server_group][0] or ansible_host == groups[server_group][0]
   block:
     - name: Copy K3s service file [Single]
       when: groups[server_group] | length == 1 or use_external_database
@@ -204,7 +204,7 @@
 - name: Start other server if any and verify status
   when:
     - (groups[server_group] | length) > 1
-    - inventory_hostname != groups[server_group][0]
+    - inventory_hostname != groups[server_group][0] and ansible_host != groups[server_group][0]
   block:
     - name: Get the token from the first server
       ansible.builtin.set_fact:


### PR DESCRIPTION
#### Changes ####
I made it so that the roles are using `ansible_host` instead of the `inventory_hostname`. That way the lookup into the list of hosts works even if the inventory hosts have an alias https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html#inventory-aliases.

#### Linked Issues ####
#397