### PR TITLE
feat: add check_mode false to run upgrade tests

### DIFF
--- a/roles/k3s_upgrade/tasks/main.yml
+++ b/roles/k3s_upgrade/tasks/main.yml
@@ -5,10 +5,12 @@
   ansible.builtin.command: k3s --version
   register: k3s_version_output
   changed_when: false
+  check_mode: false
 
 - name: Set k3s installed version
   ansible.builtin.set_fact:
     installed_k3s_version: "{{ k3s_version_output.stdout_lines[0].split(' ')[2] }}"
+  check_mode: false
 
 # We should be downloading and installing the newer version only if we are in the following case :
 #   - the installed version of K3s on the nodes is older than the requested version in ansible vars


### PR DESCRIPTION
#### Changes ####

Hi, I am running k3s in a pipeline. I want to see and check what has changed, so I need to run the upgrade task in check mode. However, this is not working without the `check_mode: false` entries.

Regards,
Michel
