### PR TITLE
fix: rewrite ufw exceptions condition

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -42,7 +42,7 @@
 
     - name: If ufw enabled, open api port
       when:
-        - ufw_status['stdout'] == "Status':' active"
+        - "'Status: active' in ufw_status['stdout']"
       community.general.ufw:
         rule: allow
         port: "{{ api_port }}"
@@ -50,7 +50,7 @@
 
     - name: If ufw enabled, open etcd ports
       when:
-        - ufw_status['stdout'] == "Status':' active"
+        - "'Status: active' in ufw_status['stdout']"
         - groups[server_group] | length > 1
       community.general.ufw:
         rule: allow
@@ -59,7 +59,7 @@
 
     - name: If ufw enabled, allow default CIDRs
       when:
-        - ufw_status['stdout'] == "Status':' active"
+        - "'Status: active' in ufw_status['stdout']"
       community.general.ufw:
         rule: allow
         src: '{{ item }}'


### PR DESCRIPTION
#### Changes ####
- Rewrite [UFW rules block](https://github.com/k3s-io/k3s-ansible/blob/078b0319416f0c236b0082d7019a01626732376d/roles/prereq/tasks/main.yml#L36C1-L37C1) `when:` condition (from the `prereq` role) since the current one does not correctly capture the UFW status.  

#### Linked Issues ####
[#401](https://github.com/k3s-io/k3s-ansible/issues/401)