### PR TITLE
fix: Condition in "Enable IPv6 forwarding" does not return a Boolean value

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -24,7 +24,7 @@
     value: "1"
     state: present
     reload: true
-  when: ansible_all_ipv6_addresses
+  when: ansible_all_ipv6_addresses | length > 0
 
 - name: Populate service facts
   ansible.builtin.service_facts:


### PR DESCRIPTION
The condition `when: ansible_all_ipv6_addresses` evaluates to a list, which in term evaluates to True,  but it seems that more recent Ansible versions do not accept that anymore:

```
Conditional result was "['fe80::...']" of type 'list', which evaluates to True. Conditionals must have a boolean result.
```

#### Changes ####

This commit adds a length check to create a real Boolean result.


#### Linked Issues ####

I did not create an issue as I want to offer an immediate fix.