### PR TITLE
Added agent_config_yaml to inventory-sample documentation

### DIFF
--- a/inventory-sample.yml
+++ b/inventory-sample.yml
@@ -42,6 +42,10 @@ k3s_cluster:
     #   This is now an inner yaml file. Maintain the indentation.
     #   YAML here will be placed as the content of /etc/rancher/k3s/config.yaml
     #   See https://docs.k3s.io/installation/configuration#configuration-file
+    # agent_config_yaml:  |
+    #   Same as server_config_yaml, but for the agent nodes.
+    #   YAML here will be placed as the content of /etc/rancher/k3s/config.yaml
+    #   See https://docs.k3s.io/installation/configuration#configuration-file
     # registries_config_yaml:  |
     #   Containerd can be configured to connect to private registries and use them to pull images as needed by the kubelet.
     #   YAML here will be placed as the content of /etc/rancher/k3s/registries.yaml


### PR DESCRIPTION
I was in need of adding the `config.yml` to agent nodes and found the `agent_config_yaml` when looking through the roles.
But I couldn't find that this variable is documentated anywhere.
So I thought I would add it to the inventory-sample since the `server_config_yaml` is already documentated there.

#### Changes ####
Small changes to the inventory-sample to reference the `agent_config_yaml` similar to `server_config_yaml`

#### Linked Issues ####
I didn't create an issue, I managed to resolve my issue on my own but thought I would help the next person by adding `agent_config_yaml` to sample config.