### PR TITLE
Fix bug: When the k3s_server_location variable is defined in the conf…

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -212,6 +212,11 @@
     - k3s_server_location is defined
     - k3s_server_location != "/var/lib/rancher/k3s"
   block:
+    - name: Make k3s server directory
+      ansible.builtin.file:
+        path: "{{ k3s_server_location }}"
+        mode: "0755"
+        state: directory
     - name: Make rancher directory
       ansible.builtin.file:
         path: "/var/lib/rancher"


### PR DESCRIPTION
…iguration, the deployment process fails on certain systems if the directory specified by k3s_server_location does not exist.

#### Changes ####
roles/prereq/tasks/main.yml
#### Linked Issues ####