### PR TITLE
ansible: Install wget and curl for k3s server download

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -10,13 +10,6 @@
   ansible.builtin.set_fact:
     installed_k3s_version: "{{ k3s_version_output.stdout_lines[0].split(' ')[2] }}"
 
-- name: Install wget and curl required for downloading the k3s server
-  ansible.builtin.package:
-    name:
-      - wget
-      - curl
-    state: latest
-
 # If airgapped, all K3s artifacts are already on the node.
 # We should be downloading and installing the newer version only if we are in one of the following cases :
 #   - we couldn't get k3s installed version in the first task of this role

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -10,6 +10,13 @@
   ansible.builtin.set_fact:
     installed_k3s_version: "{{ k3s_version_output.stdout_lines[0].split(' ')[2] }}"
 
+- name: Install wget and curl required for downloading the k3s server
+  ansible.builtin.package:
+    name:
+      - wget
+      - curl
+    state: latest
+
 # If airgapped, all K3s artifacts are already on the node.
 # We should be downloading and installing the newer version only if we are in one of the following cases :
 #   - we couldn't get k3s installed version in the first task of this role

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -258,4 +258,4 @@
     name:
       - wget
       - curl
-    state: latest
+    state: present

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -252,3 +252,10 @@
         content: "{{ registries_config_yaml }}"
         dest: "/etc/rancher/k3s/registries.yaml"
         mode: "0644"
+
+- name: Install wget and curl required for downloading the k3s binary
+  ansible.builtin.package:
+    name:
+      - wget
+      - curl
+    state: latest


### PR DESCRIPTION
These tools are required to fetch the K3s installation script during setup.
Here is the error message Set up k3s ansible on a host without `wget` or `curl` .
![image](https://github.com/user-attachments/assets/e85c433c-6148-4a7d-9256-2333f3ab0b45)

#### Changes ####
Adding wget and curl to allow downloading the k3s binary, 
#### Linked Issues ####