### PR TITLE
Disable DNF repo check when installed K3s-SELinux RPM. 

### DIFF
--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -73,6 +73,7 @@
         name: "{{ selinux_copy.results[0].dest }}"
         state: present
         disable_gpg_check: true
+        disablerepo: "*"
 
     - name: Make images directory
       ansible.builtin.file:


### PR DESCRIPTION
#### Changes ####

When the user is trying to install in an airgapped network they still may have online repos enabled in their system.  When installing the K3s SELinux RPM using DNF in Ansible we should not check any of the repos. 

More details can be found here:

[Ansible Documentation on DNF Module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/dnf_module.html#parameter-disablerepo)