### PR TITLE
Fix incorrect environment file path for agent nodes

### DIFF
--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -57,7 +57,7 @@
 - name: Add service environment variables
   when: extra_service_envs is defined
   ansible.builtin.lineinfile:
-    path: "{{ systemd_dir }}/k3s.service.env"
+    path: "{{ systemd_dir }}/k3s-agent.service.env"
     line: "{{ item }}"
   with_items: "{{ extra_service_envs }}"
 


### PR DESCRIPTION
#### Changes ####

Updated the file path in `roles/k3s_agent/tasks/main.yml` to use the correct environment file:
Changed from k3s.environment.env to k3s-agent.service.env

This ensures agent nodes can properly read environment variables.

#### Linked Issues ####

Root cause appears to originate from changes introduced in PR #416

This fix resolves deployment failure encountered during agent provisioning in proxy environments