### PR TITLE
create file if it doesn't exist

### DIFF
--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -70,6 +70,7 @@
 - name: Add the token for joining the cluster to the environment
   no_log: true # avoid logging the server token
   ansible.builtin.lineinfile:
+    create: true
     path: "{{ systemd_dir }}/k3s-agent.service.env"
     line: "{{ item }}"
   with_items:


### PR DESCRIPTION
#### Changes ####
add `create` parameter to `ansible.builtin.lineinfile` task.
This allows the file to be created if it doesn't exist.

#### Linked Issues ####
[424](https://github.com/k3s-io/k3s-ansible/issues/424)