### PR TITLE
Don't update_cache if airgapped

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -9,7 +9,7 @@
   when: ansible_distribution in ['Ubuntu']
   ansible.builtin.apt:
     name: policycoreutils  # Used by install script to restore SELinux context
-    update_cache: true
+    update_cache: "{{ airgap_dir is not defined }}"
 
 - name: Enable IPv4 forwarding
   ansible.posix.sysctl:

--- a/roles/raspberrypi/tasks/prereq/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/prereq/Ubuntu.yml
@@ -18,6 +18,6 @@
     # Fixes issues in newer Ubuntu where VXLan isn't setup right.
     # See: https://github.com/k3s-io/k3s/issues/4234
     name: linux-modules-extra-raspi
-    update_cache: true
+    update_cache: "{{ airgap_dir is not defined }}"
     state: present
   when: "ansible_distribution_version is version('20.10', '>=') and ansible_distribution_version is version('24.04', '<')"


### PR DESCRIPTION
#### Changes ####
- Don't run `apt-get update` if in an airgapped enviroment. Place reponsibility on operator to ensure OS has the necessary packages preinstalled. 

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/429