### PR TITLE
Bump version in galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: k3s
 name: orchestration
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0
+version: 1.0.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
#### Changes ####
The current release (Aug 19 2025) is 1.0.1, but the version in galaxy.yml is 1.0.0

#### Linked Issues ####