### PR TITLE
Fix ipv4 lookup

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -120,7 +120,9 @@
             groups[server_group] | default([])
             + groups[agent_group] | default([])
           )
-          | map('extract', hostvars, ['ansible_default_ipv4', 'address'])
+          | map('extract', hostvars)
+          | selectattr('ansible_default_ipv4', 'defined')
+          | map(attribute='ansible_default_ipv4.address')
           | flatten | unique | list
         }}
 


### PR DESCRIPTION
I was trying to use the project to bringup a cluster on fedora machines, but it kept failing for the firewalld step that uses ansible_default_ipv4.

The change proposed fixes the issue and lets the playbook continue.

For reference i'm using 2.18.6