### PR TITLE
feat(k3s): add support for node external IP configuration

### DIFF
--- a/inventory-sample.yml
+++ b/inventory-sample.yml
@@ -4,10 +4,13 @@ k3s_cluster:
     server:
       hosts:
         192.16.35.11:
+          # node_external_ip: "203.0.113.11"  # External IP for this server node
     agent:
       hosts:
         192.16.35.12:
+          # node_external_ip: "203.0.113.12"  # External IP for this agent node
         192.16.35.13:
+          # node_external_ip: "203.0.113.13"  # External IP for this agent node
 
   # Required Vars
   vars:

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Append node external IP to extra agent args if defined
+  # noqa var-naming[no-role-prefix]
+  when: hostvars[inventory_hostname]['node_external_ip'] is defined and hostvars[inventory_hostname]['node_external_ip'] != ""
+  ansible.builtin.set_fact:
+    extra_agent_args: "{{ extra_agent_args }} --node-ip={{ inventory_hostname }} --node-external-ip={{ hostvars[inventory_hostname]['node_external_ip'] }}"
+
 - name: Get k3s installed version
   ansible.builtin.command: k3s --version
   register: k3s_agent_version_output

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -72,6 +72,12 @@
   ansible.builtin.set_fact:
     opt_tls_san: "--tls-san={{ api_endpoint }}"
 
+- name: Append node external IP to extra server args if defined
+  # noqa var-naming[no-role-prefix]
+  when: hostvars[inventory_hostname]['node_external_ip'] is defined and hostvars[inventory_hostname]['node_external_ip'] != ""
+  ansible.builtin.set_fact:
+    extra_server_args: "{{ extra_server_args }} --node-ip={{ inventory_hostname }} --node-external-ip={{ hostvars[inventory_hostname]['node_external_ip'] }}"
+
 
 - name: Setup optional config file
   when: server_config_yaml is defined


### PR DESCRIPTION
# Add ability to configure external IPs for k3s server and agent nodes

This allows nodes to be accessible via external IP addresses when needed.

## Changes

### Features Added
- **Node IP Configuration**: Automatically sets `--node-ip` to the inventory hostname for all nodes if node_external_ip is define
- **External IP Support**: Optional per-host `node_external_ip` variable to configure `--node-external-ip` parameter
- **Maintainable Implementation**: Uses existing `extra_server_args` and `extra_agent_args` patterns for consistency

### Files Modified

#### `roles/k3s_server/tasks/main.yml`
- Added conditional task to append both `--node-ip={{ inventory_hostname }}` and `--node-external-ip` to `extra_server_args` when `node_external_ip` is defined per host

#### `roles/k3s_agent/tasks/main.yml`
- Added conditional task to append both `--node-ip={{ inventory_hostname }}` and `--node-external-ip` to `extra_agent_args` when `node_external_ip` is defined per host

#### `inventory-sample.yml`
- Added examples showing how to configure `node_external_ip` per host
- Clarified that `node_external_ip` is optional