### PR TITLE
Add: swapoff tasks in prereq role

### DIFF
--- a/roles/prereq/handlers/main.yml
+++ b/roles/prereq/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd daemon
+  ansible.builtin.systemd_service:
+    daemon_reload: true

--- a/roles/prereq/tasks/disable_swap.yml
+++ b/roles/prereq/tasks/disable_swap.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Check if swap is enabled
+  ansible.builtin.command: swapon --show=NAME --noheadings
+  register: swap_devices
+  changed_when: false
+  failed_when: false
+
+- name: Disable swap if any is active
+  ansible.builtin.command: swapoff -a
+  when: swap_devices.stdout | length > 0
+  changed_when: "'swapoff' in swap_devices.stdout or swap_devices.stdout | length > 0"
+
+- name: Remove any swap entry (UUID, device, or file) from /etc/fstab
+  ansible.builtin.replace:
+    path: /etc/fstab
+    regexp: '^\s*(UUID=[^\s]+|/dev/[^\s]+|/swap\S*)\s+none\s+swap\s+sw\s+.*$'
+    replace: ''
+  register: remove_swap_fstab
+  notify: Reload systemd daemon if needed
+
+- name: Remove empty lines from /etc/fstab (cleanup)
+  ansible.builtin.lineinfile:
+    path: /etc/fstab
+    regexp: '^$'
+    state: absent

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -260,3 +260,6 @@
         content: "{{ registries_config_yaml }}"
         dest: "/etc/rancher/k3s/registries.yaml"
         mode: "0644"
+
+- name: Disable Swap
+  ansible.builtin.include_tasks: disable_swap.yml


### PR DESCRIPTION
#### Changes ####

- Add disabling swap task
  - disable_swap task in prereq role
  - add handlers for daemon_reload after removing swap from `/etc/fstab`
  - include the disable_swap task in `main.yml`