### PR TITLE
fix: Added configurations

### DIFF
--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -13,4 +13,4 @@ extra_install_envs: {} # noqa var-naming[no-role-prefix]
 token_wait_delay: 10 # noqa var-naming[no-role-prefix]
 join_retries: 20 # noqa var-naming[no-role-prefix]
 join_wait_delay: 10 # noqa var-naming[no-role-prefix]
-host_user: "{{ ansible_user }}"
+host_user: "{{ ansible_user }}" # noqa var-naming[no-role-prefix]

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -171,7 +171,8 @@
       ansible.builtin.command: "kubectl"
       register: kubectl_installed
       ignore_errors: true
-      connection: local
+      delegate_to: 127.0.0.1
+      become: false
       become_user: "{{ host_user }}"
       changed_when: false
 
@@ -199,7 +200,8 @@
         - name: Change server address in kubeconfig on control node
           ansible.builtin.shell: |
             KUBECONFIG={{ kubeconfig }} kubectl config set-cluster default --server=https://{{ api_endpoint }}:{{ api_port }}
-          connection: local
+          delegate_to: 127.0.0.1
+          become: false
           become_user: "{{ host_user }}"
           register: k3s_server_csa_result
           changed_when:
@@ -211,7 +213,8 @@
             path: "{{ kubeconfig }}"
             regexp: "default"
             replace: "{{ cluster_context }}"
-          connection: local
+          delegate_to: 127.0.0.1
+          become: false
           become_user: "{{ host_user }}"
 
         - name: Merge with any existing kubeconfig on control node
@@ -221,7 +224,8 @@
             KUBECONFIG={{ kubeconfig }}:~/.kube/config kubectl config set-context {{ cluster_context }} --user={{ cluster_context }} --cluster={{ cluster_context }}
             KUBECONFIG={{ kubeconfig }}:~/.kube/config kubectl config view --flatten > ${TFILE}
             mv ${TFILE} ~/.kube/config
-          connection: local
+          delegate_to: 127.0.0.1
+          become: false
           become_user: "{{ host_user }}"
           register: k3s_server_mv_result
           changed_when:


### PR DESCRIPTION
#### Changes ####
- Added variables token_wait_delay, join_retries, and join_wait_delay with defaults that maintain the current behavior.
- Added a variable for host_user, that allows the host user account to differ from the user identifier on the remote target.

I tested these manually on my setup and was able to get my setup working. Let me know if there is anything I can change to make this more robust! 

#### Linked Issues ####
#454