### PR TITLE
allow for opt_tls_san to be undefined, since it's optionally defined

### DIFF
--- a/roles/k3s_server/templates/k3s.service.j2
+++ b/roles/k3s_server/templates/k3s.service.j2
@@ -27,5 +27,5 @@ ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/k3s server --data-dir {{ k3s_server_location }} {% if cluster_init == true %}--cluster-init {% endif %} \
     {% if join == true %}--server https://{{ api_endpoint }}:{{ api_port }} {% endif %} \
-    {{ opt_tls_san }} \
-    {{ extra_server_args }} 
+    {{ opt_tls_san | default('') }} \
+    {{ extra_server_args }}


### PR DESCRIPTION
#### Changes ####
the `opt_tls_san` variable introduced in  https://github.com/k3s-io/k3s-ansible/pull/443 is conditionally set, and therefore the template render will error out under conditions where that variable isn't defined.

This PR adds a default value, to allow that variable to be undefined.

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/pull/443