### PR TITLE
Pin python to 3.13 for ansible 2.19 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.
+      - name: Set up Python 3.13.
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.13.x'
 
       - name: Install test dependencies.
         run: pip3 install ansible

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.7.
+      - name: Set up Python 3.13.
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.13.x'
 
       - name: Install test dependencies.
         run: pip3 install yamllint ansible-lint ansible


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Changes ####
- Pin to older python 3.13 (still in support out to 2030). The new python 3.14 conflicts with ansible 2.19 and would require us to bump to a newer ansible core. 
#### Linked Issues ####
Failed run due to python 3.14 https://github.com/k3s-io/k3s-ansible/actions/runs/19181223809/job/55000198471?pr=460