### PR TITLE
fix(prereq): generalize RHEL package install condition to support AlmaLinux/Rocky

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -12,7 +12,7 @@
     update_cache: "{{ airgap_dir is not defined }}"
 
 - name: Install Dependent RHEL 10 Package
-  when: ansible_distribution in ['RedHat'] and ansible_distribution_major_version == "10"
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == "10"
   ansible.builtin.dnf:
     name: kernel-modules-extra   # Load br_netfilter module
     update_cache: "{{ airgap_dir is not defined }}"


### PR DESCRIPTION
This PR updates the package installation task to support all RedHat-based distributions properly.

Previously, the task condition strictly checked for `RedHat` distribution, which caused it to skip on RHEL derivatives like AlmaLinux. This resulted in the `kernel-modules-extra` package not being installed, leading to `br_netfilter` modprobe failures.

The condition has been refactored to use `ansible_os_family`, ensuring compatibility across the RHEL ecosystem.

#### Changes ####
* Refactored the `when` condition in "Install Dependent RHEL 10 Package" task.
* Replaced specific `ansible_distribution` check with `ansible_os_family == 'RedHat'`.
* Ensures `kernel-modules-extra` is installed on AlmaLinux, Rocky Linux, and CentOS.