### PR TITLE
Improve capture regex for k3s-agent service replacement

### DIFF
--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -87,7 +87,7 @@
   register: k3s_agent_service
   ansible.builtin.replace:
     path: "{{ systemd_dir }}/k3s-agent.service"
-    regexp: '^ExecStart=\/usr\/local\/bin\/k3s \\\n\s*agent.*'
+    regexp: '^ExecStart=\/usr\/local\/bin\/k3s \\\n\s*agent.*(?:\n(?:[\t\s].*|$))*'
     replace: |
       ExecStart=/usr/local/bin/k3s \
           agent \


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Changes ####
- Improve the regex to capture the additional lines of the ExecStart. 

Before, running the playbook multiple times resulted in a `k3s-agent.service` like:
```
LimitNPROC=infinity
LimitCORE=infinity
TasksMax=infinity
TimeoutStartSec=0
Restart=always
RestartSec=5s
ExecStartPre=-/sbin/modprobe br_netfilter
ExecStartPre=-/sbin/modprobe overlay
ExecStart=/usr/local/bin/k3s \
    agent \
    --server https://noder1.local:6443 \
    

    --server https://noder1.local:6443 \
    

    --server https://noder1.local:6443 \
```

Now, it results in:
```
RestartSec=5s
ExecStartPre=-/sbin/modprobe br_netfilter
ExecStartPre=-/sbin/modprobe overlay
ExecStart=/usr/local/bin/k3s \
    agent \
    --server https://noder1.local:6443 \

```

Also tested with `extra_agent_args`

#### Linked Issues ####

#464