### PR TITLE
Add basic integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,75 @@
+---
+name: Integration Test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container_os: [debian12]
+
+    # K3s requires privileged containers to run inside Docker and access to cgrougs.
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.13.
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13.x'
+
+      - name: Install Ansible and dependencies
+        run: |
+          pip install ansible
+          ansible-galaxy collection install -r collections/requirements.yml
+
+      - name: Verify Inventory
+        run: ansible-inventory -i tests/basic.yml --list
+
+      - name: Create Docker Network
+        run: docker network create k3s-ansible
+
+      - name: Start Docker containers
+        run: |
+          # Start the Server node
+          docker run -d --name server-node \
+            --privileged \
+            --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw \
+            --volume=/lib/modules:/lib/modules:ro \
+            --cgroupns=host \
+            --network=k3s-ansible \
+            geerlingguy/docker-${{ matrix.container_os }}-ansible:latest
+
+          # Start the Agent node
+          docker run -d --name agent-node \
+            --privileged \
+            --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw \
+            --volume=/lib/modules:/lib/modules:ro \
+            --cgroupns=host \
+            --network=k3s-ansible \
+            geerlingguy/docker-${{ matrix.container_os }}-ansible:latest
+
+      - name: Run Playbook
+        env:
+          ANSIBLE_FORCE_COLOR: '1'
+        run: ansible-playbook playbooks/site.yml -i tests/basic.yml
+
+
+      - name: Verify K3s is running on Server
+        run: docker exec server-node k3s kubectl get nodes | grep Ready
+
+      - name: Verify K3s is running on Agent
+        run: docker exec agent-node systemctl status k3s-agent | grep running
+
+      - name: Remove K3s from Server and Agent
+        run: ansible-playbook playbooks/reset.yml -i tests/basic.yml
+
+      - name: Stop and remove Docker containers
+        run: |
+          docker stop server-node && docker rm -f server-node
+          docker stop agent-node && docker rm -f agent-node
+          docker network rm k3s-ansible

--- a/tests/basic.yml
+++ b/tests/basic.yml
@@ -1,0 +1,18 @@
+---
+k3s_cluster:
+  children:
+    server:
+      hosts:
+        server-node:
+    agent:
+      hosts:
+        agent-node:
+  vars:
+    ansible_connection: docker
+    ansible_user: root
+    ansible_become: true
+    k3s_version: v1.33.1+k3s1
+    token: "secret12345"
+    api_endpoint: "server-node"
+    extra_server_args: "--snapshotter=native"
+    extra_agent_args: "--snapshotter=native"


### PR DESCRIPTION
#### Changes ####
- Add new PR CI, Integration Test, which uses docker to spin up 1 server + 1 agent containers with systemd, and run the ansible playbook on them. 
- Starting with just debian

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/13


#### Notes ####

Obviously within the GHA framework, we can't test different Host OS, just Ubuntu. And running the ansible nodes as docker containers can't cover the breath of a full VM, (and we can only test debian based families) but its better than no testing :).