### PR TITLE
fix: add check_mode to k3s_upgrade role

### DIFF
--- a/roles/k3s_upgrade/tasks/main.yml
+++ b/roles/k3s_upgrade/tasks/main.yml
@@ -32,6 +32,7 @@
         mode: preserve
         force: true
       loop: "{{ k3s_service_files.files }}"
+      check_mode: false
 
     - name: Stage airgap artifacts for upgrade
       when: airgap_dir is defined
@@ -70,6 +71,7 @@
         path: "{{ item.path }}.bak"
         state: absent
       loop: "{{ k3s_service_files.files }}"
+      check_mode: false
 
     - name: Restart K3s service [server]
       when: "server_group in group_names"


### PR DESCRIPTION
#### Changes ####
Added `check_mode: false` to k3s_upgrade role, first to create and second to delete the service.bak

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/472