### PR TITLE
fix: token compare tasks in k3s_server and k3s_agent roles

### DIFF
--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -73,7 +73,7 @@
   ansible.builtin.lineinfile:
     state: absent
     path: "{{ systemd_dir }}/k3s-agent.service.env"
-    regexp: "^K3S_TOKEN=\\s*(?!{{ token }}\\s*$)"
+    regexp: "^K3S_TOKEN=\\s*(?!{{ token | regex_escape }}\\s*$)"
 
 - name: Add the token for joining the cluster to the environment
   no_log: true # avoid logging the server token

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -267,7 +267,7 @@
       ansible.builtin.lineinfile:
         state: absent
         path: "{{ systemd_dir }}/k3s.service.env"
-        regexp: "^K3S_TOKEN=\\s*(?!{{ token }}\\s*$)"
+        regexp: "^K3S_TOKEN=\\s*(?!{{ token | regex_escape }}\\s*$)"
 
     - name: Add the token for joining the cluster to the environment
       no_log: true # avoid logging the server token


### PR DESCRIPTION
#### Changes ####
Generating a random passphrase with something like: openssl rand -base64 64 may include special characters. Early on, the the token comparator/delete task for the first server uses regex_escape to ensure special characters that might be mistaken as regex characters are escaped. The latter part of the tasks that run against the other nodes in the cluster don't use regex_escape causing the task to delete and replace the token unnecessarily, which in turn causes systemd service to be restarted.

#### Linked Issues ####