### PR TITLE
Ensure agents are upgraded correctly

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,6 +65,19 @@ jobs:
       - name: Verify K3s is running on Agent
         run: docker exec agent-node systemctl status k3s-agent | grep running
 
+      - name: Modify the k3s_version in inventory for upgrade
+        run: |
+          sed -i 's/k3s_version: v1.33.4+k3s1/k3s_version: v1.34.1+k3s1/' tests/basic.yml
+
+      - name: Run Upgrade Playbook
+        run: ansible-playbook playbooks/upgrade.yml -i tests/basic.yml
+
+      - name: Verify K3s upgraded on Server
+        run: docker exec server-node k3s --version | grep v1.34.
+
+      - name: Verify K3s upgraded on Agent
+        run: docker exec agent-node k3s --version | grep v1.34.
+        
       - name: Remove K3s from Server and Agent
         run: ansible-playbook playbooks/reset.yml -i tests/basic.yml
 

--- a/roles/k3s_upgrade/tasks/main.yml
+++ b/roles/k3s_upgrade/tasks/main.yml
@@ -27,6 +27,23 @@
           tags:
             - distribute_artifacts
 
+    # We must stop the service because we want to modify the service file before starting it again.
+    # INSTALL_K3S_SKIP_START does work on upgrades, because the service is already installed and started.
+    - name: Stop K3s service
+      when: k3s_upgrade_current_version is version(k3s_version, '<')
+      ansible.builtin.systemd:
+        state: stopped
+        name: "{{ (server_group in group_names) | ternary('k3s', 'k3s-agent') }}"
+
+    # We only save the token if the user did not provide one, leading to an auto-generated token on first install.
+    - name: Save the existing K3s token if needed
+      when:
+        - token is not defined
+        - inventory_hostname == groups[server_group][0] or ansible_host == groups[server_group][0]
+      ansible.builtin.command: cat /var/lib/rancher/k3s/server/node-token | cut -d':' -f4
+      register: k3s_upgrade_old_token
+      changed_when: false
+
     - name: Install new K3s Version
       # For some reason, ansible-lint thinks using enviroment with command is an error
       # even though its valid https://ansible.readthedocs.io/projects/lint/rules/inline-env-var/#correct-code
@@ -39,6 +56,7 @@
              | combine({
                "INSTALL_K3S_SKIP_START": "true",
                "INSTALL_K3S_VERSION": k3s_version,
+               "INSTALL_K3S_EXEC": ( "agent" if agent_group in group_names else "server" )
              })
              | combine(airgap_dir is defined and {"INSTALL_K3S_SKIP_DOWNLOAD": "true"} or {}) }}
       changed_when: true
@@ -119,6 +137,13 @@
               agent \
               --server https://{{ api_endpoint }}:{{ api_port }} \
               {{ extra_agent_args | default('') }}
+
+    - name: Add token to the environment
+      no_log: true # avoid logging the server token
+      ansible.builtin.lineinfile:
+        path: "{{ systemd_dir }}/{{ (agent_group in group_names) | ternary('k3s-agent.service.env', 'k3s.service.env') }}"
+        regexp: '^K3S_TOKEN='
+        line: "K3S_TOKEN={{ token is defined | ternary(token, k3s_upgrade_old_token.stdout) }}"
 
     - name: Restart K3s service [server]
       when: server_group in group_names

--- a/tests/basic.yml
+++ b/tests/basic.yml
@@ -11,7 +11,7 @@ k3s_cluster:
     ansible_connection: docker
     ansible_user: root
     ansible_become: true
-    k3s_version: v1.33.1+k3s1
+    k3s_version: v1.33.4+k3s1
     token: "secret12345"
     api_endpoint: "server-node"
     extra_server_args: "--snapshotter=native"


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Changes ####
Explicitly set the INSTALL_K3S_EXEC type for agents and servers when upgrading

Expand the integration test to check that basis upgrades work

Fix issue introduced with https://github.com/k3s-io/k3s-ansible/pull/474, when installing k3s, old ENVs are wiped out, including the Token value. We must save the old token in the case of a randomly generated one. Either way, the token value needs to be provided to the new k3s.service.env.

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/476