### PR TITLE
Update Archlinux ARM on Raspberry PI 5

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -32,6 +32,37 @@
     reload: true
   when: ansible_facts['all_ipv6_addresses'] | length > 0
 
+- name: Handle modern nftables/iptables-nft stack (Arch Linux ARM 6.18+)
+  when:
+    - ansible_facts['distribution'] == 'Archlinux'
+    - ansible_facts['kernel'] is version('6.18', '>=')
+  block:
+    - name: Check if legacy iptables is installed
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: Ensure legacy iptables is removed to avoid conflicts
+      community.general.pacman:
+        name: iptables
+        state: absent
+        force: true
+      when:
+        - "'iptables' in ansible_facts.packages"
+        - "'iptables-nft' not in ansible_facts.packages"
+
+    - name: Install iptables-nft and nftables
+      community.general.pacman:
+        name:
+          - iptables-nft
+          - nftables
+        state: present
+
+    - name: Ensure nftables is enabled and started
+      ansible.builtin.systemd:
+        name: nftables
+        state: started
+        enabled: true
+
 - name: Populate service facts
   ansible.builtin.service_facts:
 
@@ -222,7 +253,7 @@
 - name: Add /usr/local/bin to sudo secure_path
   ansible.builtin.lineinfile:
     line: 'Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin'
-    regexp: "Defaults(\\s)*secure_path(\\s)*="
+    regexp: 'Defaults(\s)*secure_path(\s)*='
     state: present
     insertafter: EOF
     path: /etc/sudoers

--- a/roles/raspberrypi/tasks/prereq/Archlinux.yml
+++ b/roles/raspberrypi/tasks/prereq/Archlinux.yml
@@ -1,13 +1,40 @@
 ---
-- name: Enable cgroup via boot commandline if not already enabled
+- name: Check for boot configuration files
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop:
+    - /boot/boot.txt
+    - /boot/cmdline.txt
+  register: boot_files
+
+- name: Set boot_file fact
+  ansible.builtin.set_fact:
+    rpi_boot_file: "{{ (boot_files.results | selectattr('stat.exists') | map(attribute='item') | list | first) | default('') }}"
+
+- name: Enable cgroup via boot commandline (boot.txt)
   ansible.builtin.replace:
     path: /boot/boot.txt
     regexp: '^(setenv bootargs console=ttyS1,115200 console=tty0 root=PARTUUID=\${uuid} rw rootwait smsc95xx.macaddr="\${usbethaddr}"(?!.*\b{{ cgroup_item }}\b).*)$'
     replace: '\1 {{ cgroup_item }}'
-  loop:
+  with_items:
     - "cgroup_enable=cpuset"
     - "cgroup_memory=1"
     - "cgroup_enable=memory"
   loop_control:
     loop_var: cgroup_item
+  when: rpi_boot_file == '/boot/boot.txt'
   notify: Regenerate bootloader image
+
+- name: Enable cgroup via boot commandline (cmdline.txt)
+  ansible.builtin.replace:
+    path: /boot/cmdline.txt
+    regexp: '^([\w](?!.*\b{{ cgroup_item }}\b).*)$'
+    replace: '\1 {{ cgroup_item }}'
+  with_items:
+    - "cgroup_enable=cpuset"
+    - "cgroup_memory=1"
+    - "cgroup_enable=memory"
+  loop_control:
+    loop_var: cgroup_item
+  when: rpi_boot_file == '/boot/cmdline.txt'
+  notify: Reboot Pi


### PR DESCRIPTION
Hello,

I have a cluster of raspberry pi model 4 and model 5 and they have different configurations for the kernel bootloader. Raspberry Pi 4 have /boot/boot.txt and Raspberry pi 5 have /boot/cmdline.txt so the current k3s collection could not be used as-is.

Additionally, the kernel linux rpi 6.18 replaced iptables by nftables so docker/podman didn't work anymore. The solution was to uninstall iptables and use nftables and iptables-nft instead on Archlinux ARM.

See this [Archlinux ARM forum post](https://archlinuxarm.org/forum/viewtopic.php?f=65&t=17368)

#### Changes ####
- updated prereq tasks to manage iptables (only on Archlinux with a kernel version >= 6.18)
- updated raspberry pi Archlinux.yml to support both files: boot.txt and cmdline.txt

Thank you for your work and I welcome any feedback for this change.
