### PR TITLE
Fix typo in README regarding requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It is also recommended that all managed nodes disable firewalls and swap. See [K
 $ ansible-galaxy collection install git+https://github.com/k3s-io/k3s-ansible.git
 ```
 
-Alternatively, add it to the [`requirement.yaml` file of your Ansible project](https://docs.ansible.com/ansible/latest/collections_guide/collections_installing.html#install-multiple-collections-with-a-requirements-file) as follows:
+Alternatively, add it to the [`requirements.yaml` file of your Ansible project](https://docs.ansible.com/ansible/latest/collections_guide/collections_installing.html#install-multiple-collections-with-a-requirements-file) as follows:
 
 ```yaml
 collections:


### PR DESCRIPTION
Small typo fix: `s/requirement.yaml/requirements.yaml/`