### PR TITLE
Support openrc systems on agent nodes, added openrc test matrix

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,10 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        container_os: [debian12]
+        service_mgr: [systemd, openrc]
 
     # K3s requires privileged containers to run inside Docker and access to cgrougs.
     steps:
+      - name: Set container OS based on service manager
+        id: set-container
+        run: |
+          if [ "${{ matrix.service_mgr }}" == "systemd" ]; then
+            echo "container_os=geerlingguy/docker-debian12-ansible" >> $GITHUB_ENV
+          else
+            echo "container_os=jrei/openrc-alpine" >> $GITHUB_ENV
+          fi
+
       - name: Checkout codebase
         uses: actions/checkout@v6
 
@@ -42,7 +51,7 @@ jobs:
             --volume=/lib/modules:/lib/modules:ro \
             --cgroupns=host \
             --network=k3s-ansible \
-            geerlingguy/docker-${{ matrix.container_os }}-ansible:latest
+            geerlingguy/docker-debian12-ansible:latest
 
           # Start the Agent node
           docker run -d --name agent-node \
@@ -51,19 +60,27 @@ jobs:
             --volume=/lib/modules:/lib/modules:ro \
             --cgroupns=host \
             --network=k3s-ansible \
-            geerlingguy/docker-${{ matrix.container_os }}-ansible:latest
+            ${{ env.container_os }}:latest
 
+      - name: Setup openrc Image
+        if: matrix.service_mgr == 'openrc'
+        run: docker exec agent-node apk add curl python3
+      
       - name: Run Playbook
         env:
           ANSIBLE_FORCE_COLOR: '1'
         run: ansible-playbook playbooks/site.yml -i tests/basic.yml
 
-
       - name: Verify K3s is running on Server
         run: docker exec server-node k3s kubectl get nodes | grep Ready
 
-      - name: Verify K3s is running on Agent
+      - name: Verify K3s is running on Agent (systemd)
+        if: matrix.service_mgr == 'systemd'
         run: docker exec agent-node systemctl status k3s-agent | grep running
+
+      - name: Verify K3s is running on Agent (openrc)
+        if: matrix.service_mgr == 'openrc'
+        run: docker exec agent-node rc-service k3s-agent status | grep started
 
       - name: Modify the k3s_version in inventory for upgrade
         run: |

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -26,19 +26,19 @@
         group: root
         mode: "0755"
 
-    - name: Download K3s binary
-      # For some reason, ansible-lint thinks using enviroment with command is an error
-      # even though its valid https://ansible.readthedocs.io/projects/lint/rules/inline-env-var/#correct-code
-      ansible.builtin.command: # noqa inline-env-var
+    - name: Download K3s and install binary
+      # noqa var-naming[no-role-prefix]
+      ansible.builtin.command:
         cmd: /usr/local/bin/k3s-install.sh
-      # Ensures that extra_install_envs are combined with required env vars
-      environment: >-
-        {{ extra_install_envs | combine({
-          "INSTALL_K3S_SKIP_START": "true",
-          "INSTALL_K3S_SYSTEMD_DIR": systemd_dir,
-          "INSTALL_K3S_VERSION": k3s_version,
-          "INSTALL_K3S_EXEC": "agent"
-        }) }}
+      environment: "{{ _install_envs }}"
+      vars:
+        _base_envs:
+          INSTALL_K3S_SKIP_START: "true"
+          INSTALL_K3S_SYSTEMD_DIR: "{{ systemd_dir }}"
+          INSTALL_K3S_VERSION: "{{ k3s_version }}"
+          INSTALL_K3S_EXEC: "agent --server https://{{ api_endpoint }}:{{ api_port }} {{ extra_agent_args }}"
+        # We overrides the extra_install_envs with required keys from _base_envs on purpose
+        _install_envs: "{{ extra_install_envs | default({}) | combine(_base_envs) }}"
       changed_when: true
 
 - name: Setup optional config file
@@ -62,41 +62,33 @@
   ansible.builtin.set_fact:
     token: "{{ hostvars[groups[server_group][0]].token }}"
 
+- name: Set k3s agent environment file based on init system
+  ansible.builtin.set_fact:
+    k3s_agent_env_file: "{{ (ansible_facts['service_mgr'] == 'systemd') | ternary(systemd_dir ~ '/k3s-agent.service.env', '/etc/rancher/k3s/k3s-agent.env') }}"
+
 - name: Add service environment variables
   when: extra_service_envs is defined
   ansible.builtin.lineinfile:
-    path: "{{ systemd_dir }}/k3s-agent.service.env"
+    path: "{{ k3s_agent_env_file }}"
     line: "{{ item }}"
   loop: "{{ extra_service_envs }}"
 
 - name: Delete any existing token from the environment if different from the new one
   ansible.builtin.lineinfile:
     state: absent
-    path: "{{ systemd_dir }}/k3s-agent.service.env"
+    path: "{{ k3s_agent_env_file }}"
     regexp: "^K3S_TOKEN=\\s*(?!{{ token | regex_escape }}\\s*$)"
 
 - name: Add the token for joining the cluster to the environment
   no_log: true # avoid logging the server token
   ansible.builtin.lineinfile:
-    path: "{{ systemd_dir }}/k3s-agent.service.env"
+    path: "{{ k3s_agent_env_file }}"
     line: "{{ item }}"
   loop:
     - "K3S_TOKEN={{ token }}"
 
-- name: Modify ExecStart in k3s-agent.service to include API endpoint and extra args
-  register: k3s_agent_service
-  ansible.builtin.replace:
-    path: "{{ systemd_dir }}/k3s-agent.service"
-    regexp: '^ExecStart=\/usr\/local\/bin\/k3s \\\n\s*agent.*(?:\n(?:[\t\s].*|$))*'
-    replace: |
-      ExecStart=/usr/local/bin/k3s \
-          agent \
-          --server https://{{ api_endpoint }}:{{ api_port }} \
-          {{ extra_agent_args }}
-
-- name: Enable and check K3s agent service
-  ansible.builtin.systemd:
+- name: Enable and start K3s agent
+  ansible.builtin.service:
     name: k3s-agent
-    daemon_reload: "{{ true if k3s_agent_service.changed else false }}"
-    state: "{{ 'restarted' if (k3s_agent_service.changed or _agent_config_result.changed) else 'started' }}"
+    state: "{{ 'restarted' if _agent_config_result.changed else 'started' }}"
     enabled: true

--- a/roles/k3s_upgrade/tasks/main.yml
+++ b/roles/k3s_upgrade/tasks/main.yml
@@ -31,7 +31,7 @@
     # INSTALL_K3S_SKIP_START does work on upgrades, because the service is already installed and started.
     - name: Stop K3s service
       when: k3s_upgrade_current_version is version(k3s_version, '<')
-      ansible.builtin.systemd:
+      ansible.builtin.service:
         state: stopped
         name: "{{ (server_group in group_names) | ternary('k3s', 'k3s-agent') }}"
 
@@ -44,11 +44,13 @@
       register: k3s_upgrade_old_token
       changed_when: false
 
-    - name: Install new K3s Version
+    - name: Install new K3s Version [server]
       # For some reason, ansible-lint thinks using enviroment with command is an error
       # even though its valid https://ansible.readthedocs.io/projects/lint/rules/inline-env-var/#correct-code
       # Skip if only reconfiguring (no version change needed)
-      when: k3s_upgrade_current_version is version(k3s_version, '<')
+      when:
+        - k3s_upgrade_current_version is version(k3s_version, '<')
+        - server_group in group_names
       ansible.builtin.command: # noqa inline-env-var
         cmd: /usr/local/bin/k3s-install.sh
       environment: >-
@@ -56,9 +58,31 @@
              | combine({
                "INSTALL_K3S_SKIP_START": "true",
                "INSTALL_K3S_VERSION": k3s_version,
-               "INSTALL_K3S_EXEC": ( "agent" if agent_group in group_names else "server" )
              })
              | combine(airgap_dir is defined and {"INSTALL_K3S_SKIP_DOWNLOAD": "true"} or {}) }}
+      changed_when: true
+
+    - name: Install new K3s Version [agent]
+      # For some reason, ansible-lint thinks using enviroment with command is an error
+      # even though its valid https://ansible.readthedocs.io/projects/lint/rules/inline-env-var/#correct-code
+      # Unlike server, we always run the install command, because we are using it to reconfigure the ENV and Args passed to k3s-agent.
+      # Instead we just skip the download/replace if airgapped or no version change is needed.
+      when:
+        - agent_group in group_names
+      # noqa var-naming[no-role-prefix]
+      ansible.builtin.command:
+        cmd: /usr/local/bin/k3s-install.sh
+      environment: "{{ _install_envs }}"
+      vars:
+        _base_envs:
+          INSTALL_K3S_SKIP_DOWNLOAD: "{{ (airgap_dir is defined or k3s_upgrade_current_version == k3s_version) | ternary('true', 'false') }}"
+          INSTALL_K3S_SKIP_START: "true"
+          INSTALL_K3S_SYSTEMD_DIR: "{{ systemd_dir }}"
+          INSTALL_K3S_VERSION: "{{ k3s_version }}"
+          INSTALL_K3S_EXEC: "agent --server https://{{ api_endpoint }}:{{ api_port }} {{ extra_agent_args }}"
+          K3S_TOKEN: "{{ token if token is defined else k3s_upgrade_old_token.stdout }}"
+        # We overrides the extra_install_envs with required keys from _base_envs on purpose
+        _install_envs: "{{ extra_install_envs | default({}) | combine(_base_envs) }}"
       changed_when: true
 
     - name: Regenerate K3s service file [server]
@@ -125,23 +149,11 @@
             cluster_init: false
             join: true
 
-    - name: Regenerate K3s service file [agent]
-      when:
-        - agent_group in group_names
-        - api_endpoint is defined
-      ansible.builtin.replace:
-        path: "{{ systemd_dir }}/k3s-agent.service"
-        regexp: '^ExecStart=\/usr\/local\/bin\/k3s \\\n\s*agent.*(?:\n(?:[\t\s].*|$))*'
-        replace: |
-          ExecStart=/usr/local/bin/k3s \
-              agent \
-              --server https://{{ api_endpoint }}:{{ api_port }} \
-              {{ extra_agent_args | default('') }}
-
-    - name: Add token to the environment
+    - name: Add token to the environment [server]
+      when: server_group in group_names
       no_log: true # avoid logging the server token
       ansible.builtin.lineinfile:
-        path: "{{ systemd_dir }}/{{ (agent_group in group_names) | ternary('k3s-agent.service.env', 'k3s.service.env') }}"
+        path: "{{ systemd_dir }}/k3s.service.env"
         regexp: '^K3S_TOKEN='
         line: "K3S_TOKEN={{ token is defined | ternary(token, k3s_upgrade_old_token.stdout) }}"
 
@@ -154,7 +166,6 @@
 
     - name: Restart K3s service [agent]
       when: agent_group in group_names
-      ansible.builtin.systemd:
+      ansible.builtin.service:
         state: restarted
-        daemon_reload: true
         name: k3s-agent


### PR DESCRIPTION
#### General Notes #####
A long term goal of mine as maintainer is to remove the entire concept of Jinja2 templating from this repo. By more heavily utilizing the default nature of the http://get.k3s.io install script, we don't need to manage and replace both the service and env files around an install or upgrade. 

This is a step towards adding complete support for openrc service manager based OSes. Since the agent role has [previously had its jinga2 template removed](https://github.com/k3s-io/k3s-ansible/pull/442), I decided to start with implementing the openrc feature with just agents. 

 I also took this opportunity to move towards the goal of consolidating the update and site playbooks. I'm currently not completely sold on the idea of completely removing the upgrade playbook, but there is significant simplification that should take place for the upgrade role. Now this PR may seem like I'm "adding" more lines to the role right now, but when I start ripping out the templating for servers, the entire role will become more simplified.  Baby steps.

#### Changes ####
- Added support openrc based OSes for k3s agents
- Reduce usage of "find and replace" for the service file, rely more upon the k3s install script to configure env and service files for us
- Added a test case to the integration test, using a openrc based alpine image for validation of feature. 

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/463
https://github.com/k3s-io/k3s-ansible/issues/485