### PR TITLE
Provide configurable server/agent group names for airgap role

### DIFF
--- a/roles/airgap/defaults/main.yml
+++ b/roles/airgap/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+server_group: server # noqa var-naming[no-role-prefix]
+agent_group: agent # noqa var-naming[no-role-prefix]

--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -100,7 +100,7 @@
     - name: Install Airgap K3s
       block:
         - name: Run K3s Install [server]
-          when: inventory_hostname in groups['server'] or ansible_host in groups['server']
+          when: inventory_hostname in groups[server_group] or ansible_host in groups[server_group]
           ansible.builtin.command:
             cmd: /usr/local/bin/k3s-install.sh
           environment:
@@ -109,7 +109,7 @@
           changed_when: true
 
         - name: Run K3s Install [agent]
-          when: inventory_hostname in groups['agent'] or ansible_host in groups['agent']
+          when: inventory_hostname in groups[agent_group] or ansible_host in groups[agent_group]
           ansible.builtin.command:
             cmd: /usr/local/bin/k3s-install.sh
           environment:


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Changes ####
Copy over the server_group and agent_group variables to the airgap role.

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/496