### PR TITLE
Fix raspberrypi boot.txt - update regex for cgroup config

### DIFF
--- a/roles/raspberrypi/tasks/prereq/Archlinux.yml
+++ b/roles/raspberrypi/tasks/prereq/Archlinux.yml
@@ -12,10 +12,10 @@
     raspberrypi_boot_file: "{{ (boot_files.results | selectattr('stat.exists') | map(attribute='item') | list | first) | default('') }}"
 
 # Arch ARM64 boots via /boot/boot.txt (UBoot), /boot/cmdline.txt only exists on legacy 32-bit systems
-- name: Enable cgroup via boot commandline
+- name: Enable cgroup via boot commandline (boot.txt)
   ansible.builtin.replace:
     path: "{{ raspberrypi_boot_file }}"
-    regexp: '^([\w](?!.*\b{{ cgroup_item }}\b).*)$'
+    regexp: '^(setenv bootargs(?!.*{{ cgroup_item }}).*)$'
     replace: '\1 {{ cgroup_item }}'
   with_items:
     - "cgroup_enable=cpuset"
@@ -23,4 +23,19 @@
     - "cgroup_enable=memory"
   loop_control:
     loop_var: cgroup_item
-  notify: "{{ (raspberrypi_boot_file == '/boot/boot.txt') | ternary('Regenerate bootloader image', 'Reboot Pi') }}"
+  when: raspberrypi_boot_file == '/boot/boot.txt'
+  notify: Regenerate bootloader image
+
+- name: Enable cgroup via boot commandline (cmdline.txt)
+  ansible.builtin.replace:
+    path: "{{ raspberrypi_boot_file }}"
+    regexp: '^(\S(?!.*{{ cgroup_item }}).*)$'
+    replace: '\1 {{ cgroup_item }}'
+  with_items:
+    - "cgroup_enable=cpuset"
+    - "cgroup_memory=1"
+    - "cgroup_enable=memory"
+  loop_control:
+    loop_var: cgroup_item
+  when: raspberrypi_boot_file == '/boot/cmdline.txt'
+  notify: Reboot Pi


### PR DESCRIPTION
Hello,

[PR #488 ](https://github.com/k3s-io/k3s-ansible/pull/488) introduced a problem in the boot.txt of Raspberry Pi model 4. The regular expression used to add the cgroup arguments was too generous and added more cgroup config than intended which broke the boot.txt file.

I have a playground cluster of different models of Raspberry pi (all on Archlinux ARM) and I've been using these changes without problem.

#### Changes ####
- update the regex to be have a more specific match search term for Archlinux

#### Linked Issues ####
[Issue #495 ](https://github.com/k3s-io/k3s-ansible/issues/495)
