### PR TITLE
Install airgap selinux rpms when avaliable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ $ cat inventory.yml
 airgap_dir: ./my-airgap # Paths are relative to the playbooks directory
 ```
 
-Additionally, if deploying on an OS with SELinux, you will also need to download the latest [k3s-selinux RPM](https://github.com/k3s-io/k3s-selinux/releases/latest) and place it in the airgap folder.
+Additionally, if deploying on an OS with SELinux, you will also need to download the latest [k3s-selinux RPM](https://github.com/k3s-io/k3s-selinux/releases/latest) and its dependencies `selinux-policy` and `container-selinux` RPMs and place them in the airgap folder.
 
 
 It is assumed that the control node has access to the internet. The playbook will automatically download the k3s install script on the control node, and then distribute all three artifacts to the managed nodes. 

--- a/roles/airgap/tasks/main.yml
+++ b/roles/airgap/tasks/main.yml
@@ -57,7 +57,9 @@
               # so we need to skip it if the file is not found
               skip: true
 
+        # Dependencies are listed first so they get installed first in the next task
         - name: Distribute K3s SELinux RPM
+          when: ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == 'Suse'
           ansible.builtin.copy:
             src: "{{ item }}"
             dest: /tmp/
@@ -65,16 +67,18 @@
             group: root
             mode: "0755"
           with_fileglob:
+            - "{{ airgap_dir }}/container-selinux*.rpm"
+            - "{{ airgap_dir }}/selinux-policy*.rpm"
             - "{{ airgap_dir }}/k3s-selinux*.rpm"
           register: airgap_selinux_copy
           ignore_errors: true
 
         - name: Install K3s SELinux RPM
           when:
-            - ansible_facts['os_family'] == 'RedHat'
+            - ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == 'Suse'
             - airgap_selinux_copy.skipped is false
           ansible.builtin.dnf:
-            name: "{{ airgap_selinux_copy.results[0].dest }}"
+            name: "{{ airgap_selinux_copy.results | selectattr('dest', 'defined') | map(attribute='dest') | list }}"
             state: present
             disable_gpg_check: true
             disablerepo: "*"


### PR DESCRIPTION
#### Changes ####
- Supports preinstalling the necessary dependencies of `container-selinux` and `selinux-policy` rpms in an airgap setup where `k3s-selinux` rpm is desired. 
- Updated the README to note that these dependencies must be manually downloaded and provided for airgap setup (or preinstalled prior). 

#### Linked Issues ####
https://github.com/k3s-io/k3s-ansible/issues/479