### PR TITLE
Fix the 'Save the existing K3s token if needed' task

### DIFF
--- a/roles/k3s_upgrade/tasks/main.yml
+++ b/roles/k3s_upgrade/tasks/main.yml
@@ -40,7 +40,7 @@
       when:
         - token is not defined
         - inventory_hostname == groups[server_group][0] or ansible_host == groups[server_group][0]
-      ansible.builtin.command: cat /var/lib/rancher/k3s/server/node-token | cut -d':' -f4
+      ansible.builtin.command: cut -d':' -f4 /var/lib/rancher/k3s/server/node-token
       register: k3s_upgrade_old_token
       changed_when: false
 


### PR DESCRIPTION
#### Changes ####

- Remove unnecessary `cat` and `|` from `Save the existing K3s token if needed` for better compatibility as it uses `ansible.builtin.command`

#### Linked Issues ####

Fixes #502 