### PR TITLE
Fix / Feature: Make server and agent role idempotent and merge upgrade logic into them

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -82,12 +82,22 @@ jobs:
         if: matrix.service_mgr == 'openrc'
         run: docker exec agent-node rc-service k3s-agent status | grep started
 
+      - name: Re-run site.yml to verify idempotency
+        env:
+          ANSIBLE_FORCE_COLOR: '1'
+        run: ansible-playbook playbooks/site.yml -i tests/basic.yml
+
+      - name: Verify K3s is still running after idempotent re-run
+        run: docker exec server-node k3s kubectl get nodes | grep Ready
+
       - name: Modify the k3s_version in inventory for upgrade
         run: |
           sed -i 's/k3s_version: v1.33.4+k3s1/k3s_version: v1.34.1+k3s1/' tests/basic.yml
 
-      - name: Run Upgrade Playbook
-        run: ansible-playbook playbooks/upgrade.yml -i tests/basic.yml
+      - name: Upgrade via site.yml
+        env:
+          ANSIBLE_FORCE_COLOR: '1'
+        run: ansible-playbook playbooks/site.yml -i tests/basic.yml
 
       - name: Verify K3s upgraded on Server
         run: docker exec server-node k3s --version | grep v1.34.
@@ -149,12 +159,22 @@ jobs:
       - name: Verify K3s is running on servers
         run: docker exec server-node1 k3s kubectl get nodes | grep Ready | wc -l | grep 3
 
+      - name: Re-run site.yml to verify idempotency
+        env:
+          ANSIBLE_FORCE_COLOR: '1'
+        run: ansible-playbook playbooks/site.yml -i tests/ha.yml
+
+      - name: Verify K3s is still running after idempotent re-run
+        run: docker exec server-node1 k3s kubectl get nodes | grep Ready | wc -l | grep 3
+
       - name: Modify the k3s_version in inventory for upgrade
         run: |
           sed -i 's/k3s_version: v1.33.4+k3s1/k3s_version: v1.34.1+k3s1/' tests/ha.yml
 
-      - name: Run Upgrade Playbook
-        run: ansible-playbook playbooks/upgrade.yml -i tests/ha.yml
+      - name: Upgrade via site.yml
+        env:
+          ANSIBLE_FORCE_COLOR: '1'
+        run: ansible-playbook playbooks/site.yml -i tests/ha.yml
 
       - name: Verify K3s upgraded on all servers
         run: |

--- a/README.md
+++ b/README.md
@@ -146,20 +146,23 @@ The format of the datastore-endpoint parameter is dependent upon the datastore b
 
 ## Upgrading
 
-A playbook is provided to upgrade K3s on all nodes in the cluster. To use it, update `k3s_version` with the desired version in `inventory.yml` and run one of the following commands. Again, the syntax is slightly different depending on whether you installed `k3s-ansible` with `ansible-galaxy` or if you run the playbook from within the cloned git repository:
-
+To upgrade K3s, update `k3s_version` in `inventory.yml` and re-run `site.yml`. The playbook detects the installed version and handles the upgrade automatically, including stopping services before replacing binaries and restarting them afterward.
 
 *Installed with ansible-galaxy*
 
 ```bash
-ansible-playbook k3s.orchestration.upgrade -i inventory.yml
+ansible-playbook k3s.orchestration.site -i inventory.yml
 ```
 
 *Running the playbook from inside the repository*
 
 ```bash
-ansible-playbook playbooks/upgrade.yml -i inventory.yml
+ansible-playbook playbooks/site.yml -i inventory.yml
 ```
+
+Re-running `site.yml` without changing `k3s_version` is safe and will only restart services if the configuration actually changed.
+
+> **Note:** A dedicated `upgrade.yml` playbook still exists for backward compatibility but is no longer required.
 
 ## Airgap Install
 

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -11,6 +11,7 @@
 - name: Setup K3S server
   hosts: server
   become: true
+  serial: 1
   roles:
     - role: k3s_server
 

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -11,7 +11,6 @@
 - name: Setup K3S server
   hosts: server
   become: true
-  serial: 1
   roles:
     - role: k3s_server
 

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -33,6 +33,16 @@
     group: root
     mode: "0755"
 
+# Capture service file hash before the install script runs, so we can
+# detect whether the script actually changed anything.
+- name: Hash K3s agent service file before install
+  when:
+    - not ansible_check_mode
+    - k3s_agent_version_output.rc != 0 or k3s_agent_installed_version is version(k3s_version, '<=')
+  ansible.builtin.stat:
+    path: "{{ systemd_dir }}/k3s-agent.service"
+  register: k3s_agent_service_before
+
 # Run the install script to install, upgrade, or reconfigure the agent.
 # On version upgrade: downloads and installs the new binary.
 # On same version: skips download, regenerates the service file to apply
@@ -55,7 +65,14 @@
       INSTALL_K3S_EXEC: "agent --server https://{{ api_endpoint }}:{{ api_port }} {{ extra_agent_args }}"
     # We overrides the extra_install_envs with required keys from _base_envs on purpose
     _install_envs: "{{ extra_install_envs | default({}) | combine(_base_envs) }}"
-  changed_when: true
+  changed_when: false
+  register: k3s_agent_install_result
+
+- name: Hash K3s agent service file after install
+  when: k3s_agent_install_result is not skipped
+  ansible.builtin.stat:
+    path: "{{ systemd_dir }}/k3s-agent.service"
+  register: k3s_agent_service_after
 
 - name: Setup optional config file
   when: agent_config_yaml is defined
@@ -108,7 +125,8 @@
     name: k3s-agent
     state: >-
       {{ 'restarted' if (_agent_config_result.changed | default(false)
+         or (k3s_agent_service_before.stat.checksum | default('', true) != k3s_agent_service_after.stat.checksum | default('', true))
          or (k3s_agent_installed_version is defined
-             and k3s_agent_installed_version is version(k3s_version, '<=')))
+             and k3s_agent_installed_version is version(k3s_version, '<')))
          else 'started' }}
     enabled: true

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -10,36 +10,52 @@
   ansible.builtin.set_fact:
     k3s_agent_installed_version: "{{ k3s_agent_version_output.stdout_lines[0].split(' ')[2] }}"
 
-# If airgapped, all K3s artifacts are already on the node.
-# We should be downloading and installing the newer version only if we are in one of the following cases :
-#   - we couldn't get k3s installed version in the first task of this role
-#   - the installed version of K3s on the nodes is older than the requested version in ansible vars
-- name: Download artifact only if needed
-  when: not ansible_check_mode and airgap_dir is undefined and ( k3s_agent_version_output.rc != 0 or k3s_agent_installed_version is version(k3s_version, '<') )
-  block:
-    - name: Download K3s install script
-      ansible.builtin.get_url:
-        url: https://get.k3s.io/
-        timeout: 120
-        dest: /usr/local/bin/k3s-install.sh
-        owner: root
-        group: root
-        mode: "0755"
+# Stop the service before upgrading to allow the install script to replace the binary.
+- name: Stop K3s agent before upgrade
+  when:
+    - k3s_agent_version_output.rc == 0
+    - k3s_agent_installed_version is version(k3s_version, '<')
+  ansible.builtin.service:
+    state: stopped
+    name: k3s-agent
 
-    - name: Download K3s and install binary
-      # noqa var-naming[no-role-prefix]
-      ansible.builtin.command:
-        cmd: /usr/local/bin/k3s-install.sh
-      environment: "{{ _install_envs }}"
-      vars:
-        _base_envs:
-          INSTALL_K3S_SKIP_START: "true"
-          INSTALL_K3S_SYSTEMD_DIR: "{{ systemd_dir }}"
-          INSTALL_K3S_VERSION: "{{ k3s_version }}"
-          INSTALL_K3S_EXEC: "agent --server https://{{ api_endpoint }}:{{ api_port }} {{ extra_agent_args }}"
-        # We overrides the extra_install_envs with required keys from _base_envs on purpose
-        _install_envs: "{{ extra_install_envs | default({}) | combine(_base_envs) }}"
-      changed_when: true
+# Download install script only when upgrading and not airgapped.
+- name: Download K3s install script
+  when:
+    - not ansible_check_mode
+    - airgap_dir is undefined
+    - k3s_agent_version_output.rc != 0 or k3s_agent_installed_version is version(k3s_version, '<')
+  ansible.builtin.get_url:
+    url: https://get.k3s.io/
+    timeout: 120
+    dest: /usr/local/bin/k3s-install.sh
+    owner: root
+    group: root
+    mode: "0755"
+
+# Run the install script to install, upgrade, or reconfigure the agent.
+# On version upgrade: downloads and installs the new binary.
+# On same version: skips download, regenerates the service file to apply
+# config changes like extra_agent_args.
+# On airgap: always skips download, binary is distributed by the airgap role.
+- name: Install and configure K3s agent
+  when:
+    - not ansible_check_mode
+    - k3s_agent_version_output.rc != 0 or k3s_agent_installed_version is version(k3s_version, '<=')
+  # noqa var-naming[no-role-prefix]
+  ansible.builtin.command:
+    cmd: /usr/local/bin/k3s-install.sh
+  environment: "{{ _install_envs }}"
+  vars:
+    _base_envs:
+      INSTALL_K3S_SKIP_DOWNLOAD: "{{ (airgap_dir is defined or (k3s_agent_installed_version is defined and k3s_agent_installed_version is version(k3s_version, '=='))) | ternary('true', 'false') }}"
+      INSTALL_K3S_SKIP_START: "true"
+      INSTALL_K3S_SYSTEMD_DIR: "{{ systemd_dir }}"
+      INSTALL_K3S_VERSION: "{{ k3s_version }}"
+      INSTALL_K3S_EXEC: "agent --server https://{{ api_endpoint }}:{{ api_port }} {{ extra_agent_args }}"
+    # We overrides the extra_install_envs with required keys from _base_envs on purpose
+    _install_envs: "{{ extra_install_envs | default({}) | combine(_base_envs) }}"
+  changed_when: true
 
 - name: Setup optional config file
   when: agent_config_yaml is defined
@@ -90,5 +106,9 @@
 - name: Enable and start K3s agent
   ansible.builtin.service:
     name: k3s-agent
-    state: "{{ 'restarted' if _agent_config_result.changed else 'started' }}"
+    state: >-
+      {{ 'restarted' if (_agent_config_result.changed | default(false)
+         or (k3s_agent_installed_version is defined
+             and k3s_agent_installed_version is version(k3s_version, '<=')))
+         else 'started' }}
     enabled: true

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -43,6 +43,17 @@
     path: "{{ systemd_dir }}/k3s-agent.service"
   register: k3s_agent_service_before
 
+# Define if k3s binary download should be skipped
+# Airgapped installs: binary is distributed by the airgap role
+# Same version reinstalls: no need to re-download the existing binary
+- name: Set install skip download flag
+  ansible.builtin.set_fact:
+    k3s_agent_skip_download: >-
+      {{ (airgap_dir is defined or
+          (k3s_agent_installed_version is defined and
+           k3s_agent_installed_version is version(k3s_version, '==')))
+         | ternary('true', 'false') }}
+
 # Run the install script to install, upgrade, or reconfigure the agent.
 # On version upgrade: downloads and installs the new binary.
 # On same version: skips download, regenerates the service file to apply
@@ -58,7 +69,7 @@
   environment: "{{ _install_envs }}"
   vars:
     _base_envs:
-      INSTALL_K3S_SKIP_DOWNLOAD: "{{ (airgap_dir is defined or (k3s_agent_installed_version is defined and k3s_agent_installed_version is version(k3s_version, '=='))) | ternary('true', 'false') }}"
+      INSTALL_K3S_SKIP_DOWNLOAD: "{{ k3s_agent_skip_download }}"
       INSTALL_K3S_SKIP_START: "true"
       INSTALL_K3S_SYSTEMD_DIR: "{{ systemd_dir }}"
       INSTALL_K3S_VERSION: "{{ k3s_version }}"

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -115,6 +115,7 @@
   register: k3s_server_saved_token
 
 - name: Set token from existing cluster
+  # noqa var-naming[no-role-prefix]
   when:
     - token is not defined
     - k3s_server_saved_token is not skipped

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -10,6 +10,20 @@
   ansible.builtin.set_fact:
     k3s_server_installed_version: "{{ k3s_server_version_output.stdout_lines[0].split(' ')[2] }}"
 
+- name: Populate service facts
+  ansible.builtin.service_facts:
+
+# Stop the service before upgrading to allow the install script to replace the binary.
+# INSTALL_K3S_SKIP_START does not prevent a running service from blocking the upgrade.
+- name: Stop K3s before upgrade
+  when:
+    - k3s_server_version_output.rc == 0
+    - k3s_server_installed_version is version(k3s_version, '<')
+    - ansible_facts.services['k3s.service'] is defined
+  ansible.builtin.service:
+    state: stopped
+    name: k3s
+
 # If airgapped, all K3s artifacts are already on the node.
 # We should be downloading and installing the newer version only if we are in one of the following cases :
 #   - we couldn't get k3s installed version in the first task of this role
@@ -89,6 +103,24 @@
         mode: "0644"
       register: _server_config_result
 
+# On re-runs where no explicit token was provided, preserve the auto-generated token
+# from the existing cluster to prevent authentication failures.
+- name: Save existing token if auto-generated
+  when:
+    - token is not defined
+    - k3s_server_version_output.rc == 0
+    - inventory_hostname == groups[server_group][0] or ansible_host == groups[server_group][0]
+  ansible.builtin.slurp:
+    src: /var/lib/rancher/k3s/server/token
+  register: k3s_server_saved_token
+
+- name: Set token from existing cluster
+  when:
+    - token is not defined
+    - k3s_server_saved_token is not skipped
+  ansible.builtin.set_fact:
+    token: "{{ k3s_server_saved_token.content | b64decode | trim }}"
+
 - name: Init first server node
   when: inventory_hostname == groups[server_group][0] or ansible_host == groups[server_group][0]
   block:
@@ -148,7 +180,9 @@
       when:
         - ansible_facts.services['k3s.service'] is defined
         - ansible_facts.services['k3s.service'].state == 'running'
-        - service_file_single.changed or service_file_ha.changed or _server_config_result.changed
+        - >-
+          service_file_single.changed or service_file_ha.changed or _server_config_result.changed
+          or (k3s_server_installed_version is defined and k3s_server_installed_version is version(k3s_version, '<'))
       ansible.builtin.systemd:
         name: k3s
         daemon_reload: true
@@ -295,7 +329,9 @@
       when:
         - ansible_facts.services['k3s.service'] is defined
         - ansible_facts.services['k3s.service'].state == 'running'
-        - k3s_server_service_file.changed or _server_config_result.changed
+        - >-
+          k3s_server_service_file.changed or _server_config_result.changed
+          or (k3s_server_installed_version is defined and k3s_server_installed_version is version(k3s_version, '<'))
       ansible.builtin.systemd:
         name: k3s
         daemon_reload: true

--- a/roles/k3s_upgrade/tasks/main.yml
+++ b/roles/k3s_upgrade/tasks/main.yml
@@ -62,6 +62,16 @@
              | combine(airgap_dir is defined and {"INSTALL_K3S_SKIP_DOWNLOAD": "true"} or {}) }}
       changed_when: true
 
+    # Define if k3s binary download should be skipped
+    # Airgapped installs: binary is distributed by the airgap role
+    # Same version reinstalls: no need to re-download the existing binary
+    - name: Set install skip download flag
+      ansible.builtin.set_fact:
+        k3s_upgrade_skip_download: >-
+          {{ (airgap_dir is defined or
+              k3s_upgrade_current_version == k3s_version)
+             | ternary('true', 'false') }}
+
     - name: Install new K3s Version [agent]
       # For some reason, ansible-lint thinks using enviroment with command is an error
       # even though its valid https://ansible.readthedocs.io/projects/lint/rules/inline-env-var/#correct-code
@@ -75,7 +85,7 @@
       environment: "{{ _install_envs }}"
       vars:
         _base_envs:
-          INSTALL_K3S_SKIP_DOWNLOAD: "{{ (airgap_dir is defined or k3s_upgrade_current_version == k3s_version) | ternary('true', 'false') }}"
+          INSTALL_K3S_SKIP_DOWNLOAD: "{{ k3s_upgrade_skip_download }}"
           INSTALL_K3S_SKIP_START: "true"
           INSTALL_K3S_SYSTEMD_DIR: "{{ systemd_dir }}"
           INSTALL_K3S_VERSION: "{{ k3s_version }}"


### PR DESCRIPTION
#### Changes ####

This PR mainly addresses the topic that using `site` on an existing cluster can be disruptive especially in combination with upgrading the version. The majority of changes was moving existing logic from the upgrade role to the server and agent role. With some minor adjustments and fixes. I also adjusted the GitHub Action integration test to validate that a re-run is idempotent and an upgrade through `site` instead of `upgrade` work. README is updated as well.

I personally prefer this way, re-run the same playbook for all cases (install, config changes, upgrades) instead of having one for the initial setup and another for upgrades. I understand that this was / is a controversial topic and no clear yes or no decision was made. Maybe this PR helps to make the decision easier ;) Worked in a single node setup, I would rely on the GHA integration test for HA to validate the changes.

Currently the upgrade playbook and role are not touched or removed, wasn't sure if they should stay for a while for backward compatibility or not.

#### Linked Issues ####

Fixes: https://github.com/k3s-io/k3s-ansible/issues/485