### PR TITLE
fix: use correct variable for k3s old token for agents in upgrade.yml

### DIFF
--- a/roles/k3s_upgrade/tasks/main.yml
+++ b/roles/k3s_upgrade/tasks/main.yml
@@ -62,6 +62,11 @@
              | combine(airgap_dir is defined and {"INSTALL_K3S_SKIP_DOWNLOAD": "true"} or {}) }}
       changed_when: true
 
+    - name: Get the token from the first server
+      # noqa var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        k3s_server_upgrade_old_token: "{{ hostvars[groups[server_group][0]].k3s_upgrade_old_token }}"
+
     - name: Install new K3s Version [agent]
       # For some reason, ansible-lint thinks using enviroment with command is an error
       # even though its valid https://ansible.readthedocs.io/projects/lint/rules/inline-env-var/#correct-code
@@ -80,7 +85,7 @@
           INSTALL_K3S_SYSTEMD_DIR: "{{ systemd_dir }}"
           INSTALL_K3S_VERSION: "{{ k3s_version }}"
           INSTALL_K3S_EXEC: "agent --server https://{{ api_endpoint }}:{{ api_port }} {{ extra_agent_args }}"
-          K3S_TOKEN: "{{ token if token is defined else k3s_upgrade_old_token.stdout }}"
+          K3S_TOKEN: "{{ token if token is defined else k3s_server_upgrade_old_token.stdout }}"
         # We overrides the extra_install_envs with required keys from _base_envs on purpose
         _install_envs: "{{ extra_install_envs | default({}) | combine(_base_envs) }}"
       changed_when: true


### PR DESCRIPTION
#### Changes ####

This Pull Request fixes upgrade.yml playbook issue for using correct old token variable in agents.

#### Linked Issues ####

#490  (perhaps only partially)

Steps to reproduce the actual issues that this PR fixes:
1) Clone repository and modify inventory,yml to match your hosts
2) Run site.yml playbook to install k3s cluster
3) Change value of k3s_version in inventory.yml to e.g. `v1.35.1+k3s1` 
4) Run upgrade.yml playbook

Expected result: upgrade.yml playbook is applied correctly to all nodes and k3s version is v1.35.1+k3s1

Actual result: upgrade.yml fails with long error message, a relevant part of which is `'K3S_TOKEN': '{{ token if token is defined else k3s_upgrade_old_token.stdout }}'}: 'dict object' has no attribute 'stdout'. 'dict object' has no attribute 'stdout'\n\n`

Reason: value of k3s_upgrade_old_token for agent hosts is actually this, not the output of ansible.builtin.command:

```
ok: [agent] => {
    "k3s_upgrade_old_token": {
        "changed": false,
        "false_condition": "inventory_hostname == groups[server_group][0] or ansible_host == groups[server_group][0]",
        "skip_reason": "Conditional result was False",
        "skipped": true
    }
}
```