### PR TITLE
fix: add check_mode support to raspberrypi role

### DIFF
--- a/roles/raspberrypi/tasks/main.yml
+++ b/roles/raspberrypi/tasks/main.yml
@@ -4,12 +4,14 @@
   register: raspberrypi_grep_cpuinfo
   failed_when: false
   changed_when: false
+  check_mode: false
 
 - name: Test for raspberry pi /proc/device-tree/model
   ansible.builtin.command: grep -E "Raspberry Pi" /proc/device-tree/model
   register: raspberrypi_grep_device_tree_model
   failed_when: false
   changed_when: false
+  check_mode: false
 
 - name: Run Raspberry Pi-specific tasks
   when:


### PR DESCRIPTION
## Changes

Adds `check_mode: false` to the two `ansible.builtin.command` tasks in the raspberrypi role that detect Pi hardware by grepping `/proc/cpuinfo` and `/proc/device-tree/model`.

## Problem

In `--check` mode, these command tasks are skipped, so the registered variables lack an `rc` attribute. The `when` condition on the Pi-specific block then evaluates incorrectly, falling through to OS prereq tasks (e.g. `Ubuntu.yml`) that try to modify `/boot/firmware/current/cmdline.txt` — which doesn't exist on non-Pi hardware.

## Fix

`check_mode: false` allows these read-only grep commands to run even in check mode so Pi detection works correctly. This follows the same pattern used in #388 for the `k3s_server` and `k3s_agent` roles.