### PR TITLE
HA joiner servers get undefined token error and generate their own random cluster secret when token is not set in inventory

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -271,7 +271,7 @@
       when: token is not defined and hostvars[groups[server_group][0]].random_token is defined
       # noqa var-naming[no-role-prefix]
       ansible.builtin.set_fact:
-        k3s_server_config: "{{ k3s_server_config | combine({'token': token}) }}"
+        k3s_server_config: "{{ k3s_server_config | combine({'token': hostvars[groups[server_group][0]].random_token}) }}"
 
     - name: Convert server config to YAML and write to file
       when: not ansible_check_mode
@@ -285,7 +285,7 @@
       ansible.builtin.lineinfile:
         state: absent
         path: "{{ k3s_server_env_file }}"
-        regexp: "^K3S_TOKEN=\\s*(?!{{ token | regex_escape }}\\s*$)"
+        regexp: "^K3S_TOKEN=\\s*(?!{{ token | default('') | regex_escape }}\\s*$)"
 
     - name: Reload systemd daemon
       when:

--- a/roles/k3s_upgrade/tasks/main.yml
+++ b/roles/k3s_upgrade/tasks/main.yml
@@ -12,6 +12,29 @@
     k3s_upgrade_current_version: "{{ k3s_upgrade_version_output.stdout_lines[0].split(' ')[2] }}"
   check_mode: false
 
+# Get the generated token if one is not defined in the configuration, we need to do this
+# outside of the next check in the case that the first server doesn't need the upgrade
+# this is same technique used in `k3s_server`
+# NOTE: this requires that the first serfver is included in any limited playbook run
+- name: Get the token if randomly generated
+  when:
+    - token is not defined
+    - inventory_hostname == groups[server_group][0] or ansible_host == groups[server_group][0]
+  block:
+    - name: Wait for token
+      ansible.builtin.wait_for:
+        path: /var/lib/rancher/k3s/server/token
+
+    - name: Read node-token from first server
+      ansible.builtin.slurp:
+        src: /var/lib/rancher/k3s/server/token
+      register: k3s_server_node_token
+
+    - name: Store random token for later servers
+      # noqa var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        random_token: "{{ k3s_server_node_token.content | b64decode | regex_replace('\n', '') }}"
+
 # We update the node configuration in the following cases:
 #   - the installed version of K3s on the nodes is older than the requested version in ansible vars
 #   - the installed version equals the requested version (to apply config changes like extra_server_args/extra_agent_args)
@@ -35,16 +58,6 @@
         state: stopped
         name: "{{ (server_group in group_names) | ternary('k3s', 'k3s-agent') }}"
 
-    # We only save the token if the user did not provide one, leading to an auto-generated token on first install.
-    # If you want the actual token value, you need to use the k3s_upgrade_old_token.stdout
-    - name: Save the existing K3s token if needed
-      when:
-        - token is not defined
-        - inventory_hostname == groups[server_group][0] or ansible_host == groups[server_group][0]
-      ansible.builtin.command: cut -d':' -f4 /var/lib/rancher/k3s/server/node-token
-      register: k3s_upgrade_old_token
-      changed_when: false
-
     - name: Construct Server config
       when: server_group in group_names
       block:
@@ -61,9 +74,12 @@
 
         # If token is not defined, use the old token
         - name: Add old token to server config
-          when: token is not defined
+          when: 
+            - token is not defined
+            # since we are pulling the token from the first server we don't want to reset it JIC
+            - inventory_hostname != groups[server_group][0] and ansible_host == groups[server_group][0]
           ansible.builtin.set_fact:
-            k3s_server_config: "{{ k3s_server_config | combine({'token': k3s_upgrade_old_token.stdout}) }}"
+            k3s_server_config: "{{ k3s_server_config | combine({'token': hostvars[groups[server_group][0]].random_token}) }}"
 
         - name: Determine if tls-san is already in config or args
           # noqa var-naming[no-role-prefix]
@@ -138,14 +154,6 @@
              | combine(airgap_dir is defined and {"INSTALL_K3S_SKIP_DOWNLOAD": "true"} or {}) }}
       changed_when: true
 
-    - name: Get the token from the first server
-      # noqa var-naming[no-role-prefix]
-      when:
-        - agent_group in group_names
-        - token is not defined
-      ansible.builtin.set_fact:
-        k3s_upgrade_old_server_token: "{{ hostvars[groups[server_group][0]].k3s_upgrade_old_token }}"
-
     - name: Install new K3s Version [agent]
       # For some reason, ansible-lint thinks using enviroment with command is an error
       # even though its valid https://ansible.readthedocs.io/projects/lint/rules/inline-env-var/#correct-code
@@ -164,7 +172,7 @@
           INSTALL_K3S_SYSTEMD_DIR: "{{ systemd_dir }}"
           INSTALL_K3S_VERSION: "{{ k3s_version }}"
           INSTALL_K3S_EXEC: "agent --server https://{{ api_endpoint }}:{{ api_port }} {{ extra_agent_args }}"
-          K3S_TOKEN: "{{ token if token is defined else k3s_upgrade_old_server_token.stdout }}"
+          K3S_TOKEN: "{{ token if token is defined else hostvars[groups[server_group][0]].random_token }}"
         # We overrides the extra_install_envs with required keys from _base_envs on purpose
         _install_envs: "{{ extra_install_envs | default({}) | combine(_base_envs) }}"
       changed_when: true

--- a/roles/k3s_upgrade/tasks/main.yml
+++ b/roles/k3s_upgrade/tasks/main.yml
@@ -75,7 +75,7 @@
         # If token is not defined, use the old token
         - name: Add old token to server config
           when: 
-            - token is not defined
+            - token is not defined and hostvars[groups[server_group][0]].random_token is defined
             # since we are pulling the token from the first server we don't want to reset it JIC
             - inventory_hostname != groups[server_group][0] and ansible_host == groups[server_group][0]
           ansible.builtin.set_fact:


### PR DESCRIPTION
## Description
When deploying an HA cluster (multiple hosts in server group) without an explicit token in inventory, additional server nodes (joiners) fail with an Ansible error and/or start k3s with a newly generated random token — creating a separate one-node cluster instead of joining the existing one.

## Two bugs are present:

### Bug 1 — combine({'token': token}) references undefined variable
In roles/k3s_server/tasks/main.yml, the "Start other server" block reads the join token from the first server's random_token fact:
```yaml
- name: Get token from first server if needed
  when: token is not defined and hostvars[groups[server_group][0]].random_token is defined
  ansible.builtin.set_fact:
    k3s_server_config: "{{ k3s_server_config | combine({'token': token}) }}"
```

The `when: condition` correctly guards against token being undefined — but the set_fact value references `token` directly, which is still undefined at this point. This causes an Ansible fatal error:
```
'token' is undefined
```
The intent is clearly to use `hostvars[groups[server_group][0]].random_token` (the value read from the first server's token file), not `token` (the inventory variable that is explicitly not set).

#### Fix:
```
k3s_server_config: "{{ k3s_server_config | combine({'token': hostvars[groups[server_group][0]].random_token}) }}"
```

### Bug 2 — lineinfile regexp references token without a default
In the same "Start other server" block, the env file cleanup task uses `token | regex_escape` without a `default()`:
```
regexp: "^K3S_TOKEN=\\s*(?!{{ token | regex_escape }}\\s*$)"
```
When token is undefined this raises a template error. The first server's equivalent task already uses `token | default('') | regex_escape` — the joiner task should be consistent.

#### Fix:
```
regexp: "^K3S_TOKEN=\\s*(?!{{ token | default('') | regex_escape }}\\s*$)"
```
With `default('')`, when token is undefined the regexp becomes `(?!\s*$)` — which removes any non-empty `K3S_TOKEN=` line, preventing a stale env token from overriding the join token written to config.yaml.

## Steps to reproduce
1. Define 3+ hosts in the server group with no token in group_vars
2. Run k3s.orchestration.site targeting all server hosts
3. Observe fatal error on joiner hosts at Get token from first server if needed
    Alternatively, if the error is suppressed: inspect /etc/rancher/k3s/config.yaml on joiner nodes — token: will be absent and k3s will generate its own secret at startup, preventing cluster join.

## Version
- k3s.orchestration: 1.2.0
- Introduced by: [No server templates in k3s_server role #509](https://github.com/k3s-io/k3s-ansible/pull/509)
