### PR TITLE
fix: kubeconfig apply block skipped when `--tags kubeconfig` passed

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -206,6 +206,7 @@
     - name: Apply K3S kubeconfig to control node
       when:
         - kubectl_installed.rc == 0 and (k3s_server_copy_yaml.changed or 'kubeconfig' in ansible_run_tags)
+      tags: kubeconfig
       block:
         - name: Copy kubeconfig to control node
           ansible.builtin.fetch:


### PR DESCRIPTION
## Description
Running the site playbook with `--tags kubeconfig` to force a kubeconfig refresh does nothing — the kubeconfig is never fetched or merged to the controller, even when kubectl is available and all `when:` conditions are satisfied.

### Steps to reproduce
```shell
ansible-playbook k3s.orchestration.site --tags kubeconfig
```

**Observe:** all tasks tagged kubeconfig run (kubectl check, k3s-copy.yaml copy, debug if present), but the kubeconfig is not fetched, the server address is not updated, and ~/.kube/config is not merged.

### Root cause
In `roles/k3s_server/tasks/main.yml`, the `Apply K3S kubeconfig to control node` block has a `when:` condition that explicitly handles the `--tags kubeconfig` case:

```yaml
when:
  - kubectl_installed.rc == 0 and (k3s_server_copy_yaml.changed or 'kubeconfig' in ansible_run_tags)
```

However, the block itself has no `tags: kubeconfig` entry. When `--tags kubeconfig` is passed, Ansible filters tasks before evaluating `when:`. A block with no matching tag is skipped entirely — the `when:` condition is never reached.

The upstream intent was clearly for `--tags kubeconfig` to force a kubeconfig refresh, but the block tag required to honour that intent was never added.

### Fix
Add `tags: kubeconfig` to the block. Tags on a block propagate to all child tasks, so the fetch, kubectl config set-cluster, context rename, and merge tasks all inherit it. Running without `--tags` is unaffected — Ansible ignores tags when no tag filter is active.
```
- name: Apply K3S kubeconfig to control node
  when:
    - kubectl_installed.rc == 0 and (k3s_server_copy_yaml.changed or 'kubeconfig' in ansible_run_tags)
  tags: kubeconfig
  block:
    ...
```

### Version
- k3s.orchestration: 1.2.0