### PR TITLE
Fix existing token retrieval for k3s server

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -271,7 +271,7 @@
       when: token is not defined and hostvars[groups[server_group][0]].random_token is defined
       # noqa var-naming[no-role-prefix]
       ansible.builtin.set_fact:
-        k3s_server_config: "{{ k3s_server_config | combine({'token': token}) }}"
+        k3s_server_config: "{{ k3s_server_config | combine({'token': hostvars[groups[server_group][0]].random_token}) }}"
 
     - name: Convert server config to YAML and write to file
       when: not ansible_check_mode
@@ -285,7 +285,7 @@
       ansible.builtin.lineinfile:
         state: absent
         path: "{{ k3s_server_env_file }}"
-        regexp: "^K3S_TOKEN=\\s*(?!{{ token | regex_escape }}\\s*$)"
+        regexp: "^K3S_TOKEN=\\s*(?!{{ token | default('') | regex_escape }}\\s*$)"
 
     - name: Reload systemd daemon
       when:


### PR DESCRIPTION
#### Changes ####
I was getting an error like this:

```
TASK [k3s.orchestration.k3s_server : Get token from first server if needed] *************************************************************************************
skipping: [k3s-02.<snipped>]
[ERROR]: Task failed: Finalization of task args for 'ansible.builtin.set_fact' failed: Error while resolving value for 'k3s_server_config': 'token' is undefined
```

This patch fixes it for me, it seems right given what the when clause is doing.
 
#### Linked Issues ####

Might be related to #529, #447 seems stale too.