### PR TITLE
Restrict permissions of registries.yaml

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -341,4 +341,4 @@
       ansible.builtin.copy:
         content: "{{ registries_config_yaml }}"
         dest: "/etc/rancher/k3s/registries.yaml"
-        mode: "0644"
+        mode: "0640"


### PR DESCRIPTION
/etc/rancher/k3s/registries.yaml may contain private registry credentials, so it should not be world-readable.

#### Changes ####

Change /etc/rancher/k3s/registries.yaml permissions from 644 to 640.

#### Linked Issues ####

#540 