### PR TITLE
fix(raspberrypi): run detection commands in check mode

### DIFF
--- a/roles/raspberrypi/tasks/main.yml
+++ b/roles/raspberrypi/tasks/main.yml
@@ -4,12 +4,14 @@
   register: raspberrypi_grep_cpuinfo
   failed_when: false
   changed_when: false
+  check_mode: false
 
 - name: Test for raspberry pi /proc/device-tree/model
   ansible.builtin.command: grep -E "Raspberry Pi" /proc/device-tree/model
   register: raspberrypi_grep_device_tree_model
   failed_when: false
   changed_when: false
+  check_mode: false
 
 - name: Run Raspberry Pi-specific tasks
   when:


### PR DESCRIPTION
#### Changes ####
`command`-based Pi detection is skipped under `--check`, so its registered `rc` is missing and the `Run Raspberry Pi-specific tasks` guard misfires when running the Pi cgroup prereq on non-Pi hosts and failing dry-runs at a missing `/boot/cmdline.txt`.