### PR TITLE
fix: use failed_when instead of ignore_errors for version detection

### DIFF
--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.command: k3s --version
   register: k3s_agent_version_output
   changed_when: false
-  ignore_errors: true
+  failed_when: false
 
 - name: Set k3s installed version
   when: not ansible_check_mode and k3s_agent_version_output.rc == 0

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.command: k3s --version
   register: k3s_server_version_output
   changed_when: false
-  ignore_errors: true
+  failed_when: false
 
 - name: Set k3s installed version
   when: not ansible_check_mode and k3s_server_version_output.rc == 0


### PR DESCRIPTION
#### Changes ####
Use `failed_when: false` instead of `ignore_errors: true` for the "Get k3s installed version" probe in `k3s_server` and `k3s_agent`. The command is expected to exit non-zero when k3s isn't installed yet (see #374); `failed_when: false` tolerates it the same way (the following `rc == 0` check still works) but reports ok, so a successful first run no longer prints a red `FAILED!`/`ignoring` line.

#### Linked Issues ####
Refs #374