### PR TITLE
fix: read hostname from ansible_facts in the TLS SAN condition

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -48,7 +48,7 @@
     - name: Add TLS SAN to config if needed
       when:
         - api_endpoint is defined
-        - api_endpoint != ansible_hostname
+        - api_endpoint != ansible_facts['hostname']
         - not (_api_endpoint_in_config | trim | bool)
         - not (_api_endpoint_in_args | trim | bool)
       ansible.builtin.set_fact:

--- a/roles/k3s_upgrade/tasks/main.yml
+++ b/roles/k3s_upgrade/tasks/main.yml
@@ -84,7 +84,7 @@
         - name: Add TLS SAN to config if needed
           when:
             - api_endpoint is defined
-            - api_endpoint != ansible_hostname
+            - api_endpoint != ansible_facts['hostname']
             - not (_api_endpoint_in_config | trim | bool)
             - not (_api_endpoint_in_args | trim | bool)
           ansible.builtin.set_fact:


### PR DESCRIPTION
#### Changes ####
`ansible_hostname` is a top-level fact injected by `INJECT_FACTS_AS_VARS`, which is deprecated. Read the value from `ansible_facts` instead.